### PR TITLE
Add dataset description

### DIFF
--- a/conf/dataset.jsonld
+++ b/conf/dataset.jsonld
@@ -1,0 +1,92 @@
+{
+   "@context":{
+      "id":"@id",
+      "type":"@type",
+      "@vocab":"http://schema.org/",
+      "accrualPeriodicity":{
+         "@id":"http://purl.org/dc/terms/accrualPeriodicity",
+         "@type":"@id"
+      },
+      "license":"http://purl.org/dc/terms/license",
+      "label":{
+         "@id":"http://www.w3.org/2000/01/rdf-schema#label",
+         "@container":"@language"
+      },
+      "description":{
+         "@container":"@language"
+      },
+      "distribution": "http://www.w3.org/ns/dcat#distribution",
+      "Distribution":"http://www.w3.org/ns/dcat#Distribution",
+      "accessURL":"http://www.w3.org/ns/dcat#accessURL",
+      "mediaType":"http://www.w3.org/ns/dcat#mediaType"
+   },
+   "id":"http://lobid.org/resources/dataset#!",
+   "type":"Dataset",
+   "name":"lobid-gnd",
+   "alternateName": "LOD-API für die Gemeinsame Normdatei (GND)",
+   "description":{
+      "de":"<p>Die Gemeinsame Normdatei (GND) enthält über 15 Millionen Normdatensätze. Sie wird zur Katalogisierung von Literatur in Bibliotheken, sowie von Archiven, Museen, und verschiedenen Kontexten genutzt.</p><p>Die GND enthält normierte Einträge für Personen, Körperschaften, Kongresse, Geografika, Sachschlagwörter und Werktitel. Sie wird von der Deutschen Nationalbibliothek (DNB), den deutschsprachigen Bibliotheksverbünden, der Zeitschriftendatenbank (ZDB) und zahlreichen weiteren Institutionen kooperativ geführt. Die Daten sind unter CC0 lizenziert.</p><p>lobid-gnd bietet eine <a href=\"http://lobid.org/gnd/search\">Rechercheoberfläche zum Durchsuchen der GND</a> und eine <a href=\"http://lobid.org/gnd/api\">Web-API auf Basis von JSON-LD</a> zur Verwendung der Daten in verschiedenen Kontexten.</p>",
+      "en":"<p>The Integrated Authority File (GND) contains more than 15 Million authority records. It is used for cataloging in libraries as well as in archives, museums and other contexts.</p><p>The GND contains authority records for persons, corporate bodies, congresses, places, subject headings and works. It is maintained cooperatively by the German National Library (DNB), German-speaking library networks, the German Union Catalogue of Serials (ZDB) and many other institutions. The data is licensed under CC0.</p><p>lobid-gnd provides a <a href=\"http://lobid.org/gnd/search\">search interface for exploring GND</a> and <a href=\"http://lobid.org/gnd/api\">a web API based on JSON-LD</a> to enable use of the data in different contexts.</p>"
+   },
+   "keywords":[
+      "authority data",
+      "Germany",
+      "Austria",
+      "Switzerland"
+   ],
+   "datePublished":"2018-07-11",
+   "contactPoint":"http://lobid.org/contact",
+   "accrualPeriodicity":{
+      "id":"http://purl.org/linked-data/sdmx/2009/code#freq-B",
+      "label":{
+         "en":"Daily - business week",
+         "de":"Täglich (werktags)"
+      }
+   },
+   "inLanguage":[
+      "de"
+   ],
+   "publisher":{
+      "id":"http://lobid.org/organisations/DE-605#!",
+      "label":{
+         "de":"Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen",
+         "en":"North Rhine-Westphalian Library Service"
+      },
+      "alternateName":[
+         "hbz"
+      ]
+   },
+   "isBasedOn": {
+     "type": "Dataset",
+     "id": "http://d-nb.info/gnd/7749153-1",
+     "label":{
+        "de":"Gemeinsame Normdatei (GND)",
+        "en":"Integrated Authority File (GND)"
+     },
+     "description":{
+        "de":"Genutzt werden die von der DNB bereitgestellten RDF-Datenabzüge der GND, siehe <a href=\"http://www.dnb.de/DE/Service/DigitaleDienste/LinkedData/linkeddata_node.html\">http://www.dnb.de/DE/Service/DigitaleDienste/LinkedData/linkeddata_node.html</a>.",
+        "en":"lobid-gnd uses the RDF dumps of the GND as provided by DNB, see <a href=\"http://www.dnb.de/EN/Service/DigitaleDienste/LinkedData/linkeddata_node.html\"></a>."
+     },
+     "license": "https://creativecommons.org/publicdomain/zero/1.0/"
+   },
+   "distribution":[
+      {
+         "id":"http://lobid.org/gnd/search",
+         "type":"Distribution",
+         "label": {
+           "de": "lobid-gnd-API",
+           "en": "lobid-gnd API"
+         },
+         "description": {
+         "en": "<p>The API gives access to machine-readable data (JSON-LD via HTTP). For documentation see <a href=\"http://lobid.org/gnd/api\">http://lobid.org/gnd/api</a>.</p>",
+         "de": "<p>Die API bietet Zugriff auf strukturierte Daten (JSON-LD via HTTP). Die Dokumentation befindet sich unter <a href=\"http://lobid.org/gnd/api\">http://lobid.org/gnd/api</a>.</p>"
+         },
+         "accessURL":"http://lobid.org/gnd/search",
+         "mediaType":[
+            "application/json",
+            "application/ld+json"
+         ],
+   "license": "https://creativecommons.org/publicdomain/zero/1.0/"
+      }
+   ]
+}


### PR DESCRIPTION
See https://github.com/hbz/lobid-gnd/issues/134.

AFAIK, we are using the dataset.jsonld for the respective service's homepage. We probably should implement it like this with lobid-gnd. I already used the current text from the home page as description in the dataset file but did a few adjustments.