### PR TITLE
Add properties for provenance information to context

### DIFF
--- a/conf/context.jsonld
+++ b/conf/context.jsonld
@@ -71,6 +71,12 @@
       "label": "http://www.w3.org/2000/01/rdf-schema#label",
       "contentType": "http://rdaregistry.info/Elements/u/P60049",
       "collection": "http://d-nb.info/standards/elementset/dnb#isDescribedIn",
+      "describedBy": "http://www.w3.org/2007/05/powder-s#describedby",
+      "license": "http://purl.org/dc/terms/license",
+      "dateModified": {
+        "@id": "http://purl.org/dc/terms/modified",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
       "publisher": "http://purl.org/dc/elements/1.1/publisher",
       "abbr": "http://dbpedia.org/ontology/abbreviation",
       "name": "http://xmlns.com/foaf/0.1/name",

--- a/conf/context.jsonld
+++ b/conf/context.jsonld
@@ -1254,6 +1254,10 @@
          "@id":"http://www.w3.org/2004/02/skos/core#broadMatch",
          "@container":"@set"
       },
+      "narrowMatch": {
+         "@id":"http://www.w3.org/2004/02/skos/core#narrowMatch",
+         "@container":"@set"
+      },
       "relatedMatch": {
          "@id":"http://www.w3.org/2004/02/skos/core#relatedMatch",
          "@container":"@set"


### PR DESCRIPTION
Resolves #89.

Furthermore, I added `skos:narrowMatch` to the context. I noticed that it currently is used in 249 entries with `skos:narrowMatch`, see http://lobid.org/gnd/search?q=_exists_%3A%22skos%3AnarrowMatch%22. (As I removed the skos prefix in c1ed3434a446109d55eade36f4911ea1c3662245 the whole URI would have been used after re-indexing.) 

We will have to re-index the whole GND to see the changes. Do we need an issue for this? If yes, we could adjust #146...