### PR TITLE
171 check not compacted fields

### DIFF
--- a/checkCompactedProperties.sh
+++ b/checkCompactedProperties.sh
@@ -30,7 +30,7 @@ fi
 
 echo "there are uncompacted fields: $MESSAGE"
 
-mail -s "Alert GND: found not compacted field(s)!" "$RECIPIENT@hbz-nrw.de" -a "From: sol@quaoar1" << EOF
+mail -s "Alert GND: found not compacted field(s)!" "$RECIPIENT@hbz-nrw.de" << EOF
 $MESSAGE
 EOF
 exit 1

--- a/checkCompactedProperties.sh
+++ b/checkCompactedProperties.sh
@@ -1,13 +1,36 @@
-search=http
-index="gnd-staging"
-recipient=lobid-admin
+#!/bin/bash
+# See #171.
+# Shall be started after indexing of an update or a fulldump.
+# Checks if there are uncompacted field. If so, mail an alert.
+# First parameter is the name of the index that will be checked. Without
+# parameter, the _newest_ gnd-prefixed index is determined and checked - this
+# can be used after indexing a fulldump.
 
-message=$(curl weywot5.hbz-nrw.de:9200/$index/_mapping | jq -r 'paths | map(.|tostring)|join(".")' |grep $search.*properties. |grep -vE '.properties(.id|.label)(.*)$' |grep -vE '.properties$')
-
-if [ -z "$message" ]; then
-        echo "empty - return"
-        exit 0
+set -euo pipefail # See http://redsymbol.net/articles/unofficial-bash-strict-mode/
+IFS=$'\n\t'
+ES="weywot5.hbz-nrw.de:9200"
+INDEX=""
+if [ -n "${1-}" ]; then
+	INDEX=$1
 fi
-mail -s "GND: not compacted fields!" "$recipient@hbz-nrw.de" -a "From: sol@quaoar1" << EOF
-        $message
+SEARCH=http
+RECIPIENT=lobid-admin
+
+if [ -z ${INDEX-} ]; then
+	INDEX=$(curl $ES/_settings |jq .[].settings.index.provided_name |grep gnd | tr -d \" | sort |tail -n1)
+fi
+echo "check index-name: $INDEX"
+
+MESSAGE=$(curl $ES/$INDEX/_mapping | jq -r 'paths | map(.|tostring)|join(".")' |grep $SEARCH.*type$ || exit 0)
+
+if [ -z "${MESSAGE-}" ]; then
+	echo "no uncompacted fields found"
+	exit 0
+fi
+
+echo "there are uncompacted fields: $MESSAGE"
+
+mail -s "Alert GND: found not compacted field(s)!" "$RECIPIENT@hbz-nrw.de" -a "From: sol@quaoar1" << EOF
+$MESSAGE
 EOF
+exit 1

--- a/checkCompactedProperties.sh
+++ b/checkCompactedProperties.sh
@@ -1,0 +1,13 @@
+search=http
+index="gnd-staging"
+recipient=lobid-admin
+
+message=$(curl weywot5.hbz-nrw.de:9200/$index/_mapping | jq -r 'paths | map(.|tostring)|join(".")' |grep $search.*properties. |grep -vE '.properties(.id|.label)(.*)$' |grep -vE '.properties$')
+
+if [ -z "$message" ]; then
+        echo "empty - return"
+        exit 0
+fi
+mail -s "GND: not compacted fields!" "$recipient@hbz-nrw.de" -a "From: sol@quaoar1" << EOF
+        $message
+EOF

--- a/cron.sh
+++ b/cron.sh
@@ -1,24 +1,26 @@
 #!/bin/bash
-set -euo pipefail # See http://redsymbol.net/articles/unofficial-bash-strict-mode/
-IFS=$'\n\t'
-
+# See http://redsymbol.net/articles/unofficial-bash-strict-mode/
+# explicitly without "-e" for it should not exit immediately when failed but write a mail
+set -uo pipefail # See http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # Execute via crontab by hduser@weywot1:
 # 00 1 * * * ssh sol@quaoar1 "cd /home/sol/git/lobid-gnd ; bash -x cron.sh >> logs/cron.sh.log 2>&1"
 
+IFS=$'\n\t'
+RECIPIENT=lobid-admin
 sbt "runMain apps.ConvertUpdates $(tail -n1 GND-lastSuccessfulUpdate.txt)"
 
-# copy and index to stage:
+# copy and index to stage, and check:
 scp GND-updates.jsonl weywot2:git/lobid-gnd/
 ssh sol@weywot2 "cd /home/sol/git/lobid-gnd ; sh restart.sh lobid-gnd;
- tail -f ./logs/application.log |grep -q "main - Application started (Prod)" ; ./checkCompactedProperties.sh"
+ tail -f ./logs/application.log |grep -q main\ -\ Application\ started  ; bash ./checkCompactedProperties.sh gnd"
 
-# index to procutive instance:
+# if check ok, index to productive instance:
 if [  $? -eq 0 ]; then
-	#sh restart.sh lobid-gnd
-	MESSAGE="check war gut :)"
+	sh restart.sh lobid-gnd
 	else MESSAGE="check fail :("
-fi
+mail -s "Alert GND: test bad " "$RECIPIENT@hbz-nrw.de" << EOF
+Because of these uncompacted fields the data is not indexed into the productive service:
 
-mail -s "Alert GND: test" "$rece@hbz-nrw.de" -a "From: sol@weywot2" << EOF
 $MESSAGE
 EOF
+fi

--- a/cron.sh
+++ b/cron.sh
@@ -6,6 +6,19 @@ IFS=$'\n\t'
 # 00 1 * * * ssh sol@quaoar1 "cd /home/sol/git/lobid-gnd ; bash -x cron.sh >> logs/cron.sh.log 2>&1"
 
 sbt "runMain apps.ConvertUpdates $(tail -n1 GND-lastSuccessfulUpdate.txt)"
-sh restart.sh lobid-gnd
+
+# copy and index to stage:
 scp GND-updates.jsonl weywot2:git/lobid-gnd/
-ssh sol@weywot2 "cd /home/sol/git/lobid-gnd ; sh restart.sh lobid-gnd"
+ssh sol@weywot2 "cd /home/sol/git/lobid-gnd ; sh restart.sh lobid-gnd;
+ tail -f ./logs/application.log |grep -q "main - Application started (Prod)" ; ./checkCompactedProperties.sh"
+
+# index to procutive instance:
+if [  $? -eq 0 ]; then
+	#sh restart.sh lobid-gnd
+	MESSAGE="check war gut :)"
+	else MESSAGE="check fail :("
+fi
+
+mail -s "Alert GND: test" "$rece@hbz-nrw.de" -a "From: sol@weywot2" << EOF
+$MESSAGE
+EOF


### PR DESCRIPTION
See #171.

If deployed the gnd updates will be checked automatically. If uncompacted fields are found a mail is wrotten to the lobid admins. This also prevents updating the data, so you should take some action so that the data will not be outdated.

If indexing a fulldump, the script `checkCompactedProperties.sh` must be called manually. It will check the newest "gnd"-prefixed index.