### PR TITLE
Tweak reconciliation query

### DIFF
--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -179,7 +179,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 
 	public Result authority(String id, String format) {
 		SearchHits hits = index
-				.query(String.format("deprecatedUri:\"%s%s\"", AuthorityResource.DNB_PREFIX, id), "", "", "", 0, 1)
+				.query(String.format("deprecatedUri:\"%s%s\"", AuthorityResource.DNB_PREFIX, id), "", "", 0, 1)
 				.getHits();
 		if (hits.getTotalHits() > 0 && !hits.getAt(0).getId().equals(id)) {
 			return movedPermanently(controllers.routes.HomeController.authority(hits.getAt(0).getId(), format));
@@ -226,7 +226,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 
 	private List<String> creatorOf(String id) {
 		String q = String.format("firstAuthor:\"%s\" OR firstComposer:\"%s\"", id, id);
-		SearchResponse response = index.query(q, "", "", "", 0, 1000);
+		SearchResponse response = index.query(q, "", "", 0, 1000);
 		Stream<String> ids = Arrays.asList(response.getHits().getHits()).stream()
 				.map(hit -> AuthorityResource.DNB_PREFIX + hit.getId());
 		return ids.collect(Collectors.toList());
@@ -315,7 +315,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 		}
 		String queryString = (q == null || q.isEmpty()) ? "*" : q;
 		try {
-			SearchResponse response = index.query(queryString, filter, "", sort, from, size);
+			SearchResponse response = index.query(queryString, filter, sort, from, size);
 			response().setHeader("Access-Control-Allow-Origin", "*");
 			String[] formatAndConfig = format == null ? new String[] {} : format.split(":");
 			boolean returnSuggestions = formatAndConfig.length == 2;

--- a/test/modules/IndexQueryTest.java
+++ b/test/modules/IndexQueryTest.java
@@ -133,7 +133,7 @@ public class IndexQueryTest extends IndexTest {
 
 	private AuthorityResource first(String sort) {
 		return new AuthorityResource(
-				Json.parse(index.query("*", "", "", sort, 0, 10).getHits().getHits()[0].getSourceAsString()));
+				Json.parse(index.query("*", "", sort, 0, 10).getHits().getHits()[0].getSourceAsString()));
 	}
 
 	@Test(expected = SearchPhaseExecutionException.class)


### PR DESCRIPTION
- Limit main query to name fields
- Boost optional properties query

Will resolve https://github.com/hbz/lobid-gnd/issues/228