### PR TITLE
Fix reconcile GET queries in the browser

### DIFF
--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
-import controllers.Accept.Format;
 import models.AuthorityResource;
 import models.GndOntology;
 import modules.IndexComponent;
@@ -77,7 +76,8 @@ public class Reconcile extends Controller {
 	 *         data (if queries and extend are empty), wrapped in `callback`
 	 */
 	public Result main(String callback, String queries, String extend) {
-		if (Accept.formatFor(null, request().acceptedTypes()) == Accept.Format.HTML) {
+		if (Accept.formatFor(null, request().acceptedTypes()) == Accept.Format.HTML
+				&& queries.isEmpty() && extend.isEmpty()) {
 			return ok(views.html.reconcile.render());
 		} else {
 			ObjectNode result = queries.isEmpty() && extend.isEmpty() ? metadata()


### PR DESCRIPTION
Like `/gnd/reconcile?queries={"q1":{"query":"Twain, Mark"}}`

Deployed to test, see:

https://test.lobid.org/gnd/reconcile
https://test.lobid.org/gnd/reconcile?queries={"q1":{"query":"Twain,+Mark"}}