### PR TITLE
Fix identifierSpace in reconciliation service manifest

### DIFF
--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -92,7 +92,7 @@ public class Reconcile extends Controller {
 		final String host = HomeController.config("host");
 		ObjectNode result = Json.newObject();
 		result.put("name", "GND reconciliation for OpenRefine");
-		result.put("identifierSpace", host + "/gnd/");
+		result.put("identifierSpace", AuthorityResource.GND_PREFIX);
 		result.put("schemaSpace", "https://d-nb.info/standards/elementset/gnd#AuthorityResource");
 		result.set("defaultTypes", TYPES);
 		result.set("view", Json.newObject()//

--- a/test/controllers/ReconcileTest.java
+++ b/test/controllers/ReconcileTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 
+import models.AuthorityResource;
 import modules.IndexTest;
 import play.Application;
 import play.Logger;
@@ -59,6 +60,7 @@ public class ReconcileTest extends IndexTest {
 			assertThat(result.contentType().get(), is(equalTo("application/json")));
 			assertNotNull(Json.parse(contentAsString(result)));
 			assertThat(contentAsString(result), containsString("https:"));
+			assertThat(contentAsString(result), containsString(AuthorityResource.GND_PREFIX));
 			assertThat(contentAsString(result), not(containsString("http:")));
 			assertThat(result.header("Access-Control-Allow-Origin").get(), is(equalTo("*")));
 		});


### PR DESCRIPTION
While working on https://codeberg.org/fsteeg/recon-artikel I discovered we're not using `identifierSpace` correctly in our reconciliation service manifest.

Quoting from [the spec](https://reconciliation-api.github.io/specs/latest/#identifier-and-schema-spaces):

> If two different reconciliation services expose the same entities and properties, then they SHOULD use the same identifier and schema space URIs, signalling that (for instance) the Data Extension service of the first one can be used on reconciliation candidates by the second

See also discussion on the [mailing list]( https://lists.w3.org/Archives/Public/public-reconciliation/2019Oct/0002.html):

> identifierSpace: This property defines the base URL under which results returned by the reconciliation service are located.  For example, all services that reconcile against Wikidata should use `http://www.wikidata.org/entity/` as their identifierSpace regardless of who hosts that reconciliation service.

So we should use `https://d-nb.info/gnd/`, not `https://lobid.org/gnd/` for interoperability.

@acka47 I'm not opening a separate issue, I suggest you review here. Deployed to test:

`curl  https://test.lobid.org/gnd/reconcile | jq .identifierSpace`

I tested basic reconciliation and data extension in OpenRefine with test, seems to work fine.