### PR TITLE
Add single-level broader IDs for default and suggested types

### DIFF
--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -97,7 +97,7 @@ public class Reconcile extends Controller {
 	private ObjectNode metadata() {
 		final String host = HomeController.config("host");
 		ObjectNode result = Json.newObject();
-		result.putArray("versions").add("0.2");
+		result.putArray("versions").add("0.1").add("0.2");
 		result.put("name", "GND reconciliation for OpenRefine");
 		result.put("identifierSpace", AuthorityResource.GND_PREFIX);
 		result.put("schemaSpace", "https://d-nb.info/standards/elementset/gnd#AuthorityResource");

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -64,7 +64,7 @@ public class Reconcile extends Controller {
 						.put("id", type)//
 						.put("name", GndOntology.label(type));
 				return type.equals(AuthorityResource.ID) ? map.build()
-						: map.put("broader", AuthorityResource.ID).build();
+						: map.put("broader", Arrays.asList(AuthorityResource.ID)).build();
 			}));
 
 	/**
@@ -248,7 +248,7 @@ public class Reconcile extends Controller {
 					.put("id", id)//
 					.put("name", GndOntology.label(id));
 			String broader = HomeController.configNested("types", id);
-			return Json.toJson(broader == null ? map.build() : map.put("broader", broader).build());
+			return Json.toJson(broader == null ? map.build() : map.put("broader", Arrays.asList(broader)).build());
 		});
 		return labelledIds;
 	}

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -64,7 +64,11 @@ public class Reconcile extends Controller {
 						.put("id", type)//
 						.put("name", GndOntology.label(type));
 				return type.equals(AuthorityResource.ID) ? map.build()
-						: map.put("broader", Arrays.asList(AuthorityResource.ID)).build();
+						: map.put("broader",
+								Arrays.asList(ImmutableMap.of(//
+										"id", AuthorityResource.ID, //
+										"name", GndOntology.label(AuthorityResource.ID))))
+								.build();
 			}));
 
 	/**
@@ -247,8 +251,13 @@ public class Reconcile extends Controller {
 			ImmutableMap.Builder<Object, Object> map = ImmutableMap.builder()//
 					.put("id", id)//
 					.put("name", GndOntology.label(id));
-			String broader = HomeController.configNested("types", id);
-			return Json.toJson(broader == null ? map.build() : map.put("broader", Arrays.asList(broader)).build());
+			String broaderId = HomeController.configNested("types", id);
+			return Json.toJson(broaderId == null ? map.build()
+					: map.put("broader",
+							Arrays.asList(ImmutableMap.of(//
+									"id", broaderId, //
+									"name", GndOntology.label(broaderId))))
+							.build());
 		});
 		return labelledIds;
 	}

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -93,6 +93,7 @@ public class Reconcile extends Controller {
 	private ObjectNode metadata() {
 		final String host = HomeController.config("host");
 		ObjectNode result = Json.newObject();
+		result.putArray("versions").add("0.2");
 		result.put("name", "GND reconciliation for OpenRefine");
 		result.put("identifierSpace", AuthorityResource.GND_PREFIX);
 		result.put("schemaSpace", "https://d-nb.info/standards/elementset/gnd#AuthorityResource");

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -60,7 +60,11 @@ public class Reconcile extends Controller {
 	private static final JsonNode TYPES = Json
 			.toJson(HomeController.CONFIG.getStringList("topLevelTypes").stream().map(t -> {
 				String type = t.equals("Person") ? "DifferentiatedPerson" : t;
-				return ImmutableMap.of("id", type, "name", GndOntology.label(type));
+				ImmutableMap.Builder<Object, Object> map = ImmutableMap.builder()//
+						.put("id", type)//
+						.put("name", GndOntology.label(type));
+				return type.equals(AuthorityResource.ID) ? map.build()
+						: map.put("broader", AuthorityResource.ID).build();
 			}));
 
 	/**
@@ -239,9 +243,13 @@ public class Reconcile extends Controller {
 	}
 
 	private Stream<JsonNode> labelledIds(Stream<String> ids) {
-		Stream<JsonNode> labelledIds = ids.map(id -> Json.toJson(ImmutableMap.of(//
-				"id", id, //
-				"name", GndOntology.label(id))));
+		Stream<JsonNode> labelledIds = ids.map(id -> {
+			ImmutableMap.Builder<Object, Object> map = ImmutableMap.builder()//
+					.put("id", id)//
+					.put("name", GndOntology.label(id));
+			String broader = HomeController.configNested("types", id);
+			return Json.toJson(broader == null ? map.build() : map.put("broader", broader).build());
+		});
 		return labelledIds;
 	}
 

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -191,6 +191,7 @@ public class Reconcile extends Controller {
 	 */
 	public Result suggest(String callback, String service, String prefix, String type, String typeStrict, int limit,
 			int start) {
+		response().setHeader("Access-Control-Allow-Origin", "*");
 		switch (Service.valueOf(service.toUpperCase())) {
 		case ENTITY:
 			Logger.debug("Suggest {}:{} -> {}", service, prefix, Service.ENTITY);

--- a/app/models/AuthorityResource.java
+++ b/app/models/AuthorityResource.java
@@ -29,6 +29,7 @@ import play.libs.Json;
 
 public class AuthorityResource {
 
+	public static final String ID = "AuthorityResource";
 	private static final int SHORTEN = 5;
 	public static final String DNB_PREFIX = "https://d-nb.info/";
 	public static final String GND_PREFIX = DNB_PREFIX + "gnd/";
@@ -75,7 +76,7 @@ public class AuthorityResource {
 	}
 
 	public List<String> getType() {
-		return type.stream().filter(t -> !t.equals("AuthorityResource")).collect(Collectors.toList());
+		return type.stream().filter(t -> !t.equals(ID)).collect(Collectors.toList());
 	}
 
 	public void setType(List<String> type) {

--- a/test/controllers/ReconcileTest.java
+++ b/test/controllers/ReconcileTest.java
@@ -61,6 +61,8 @@ public class ReconcileTest extends IndexTest {
 			assertNotNull(Json.parse(contentAsString(result)));
 			assertThat(contentAsString(result), containsString("https:"));
 			assertThat(contentAsString(result), containsString(AuthorityResource.GND_PREFIX));
+			assertThat(contentAsString(result), containsString(AuthorityResource.ID));
+			assertThat(contentAsString(result), containsString("broader"));
 			assertThat(contentAsString(result), not(containsString("http:")));
 			assertThat(result.header("Access-Control-Allow-Origin").get(), is(equalTo("*")));
 		});
@@ -74,6 +76,18 @@ public class ReconcileTest extends IndexTest {
 			assertNotNull(result);
 			assertThat(result.contentType().get(), is(equalTo("application/json")));
 			assertThat(result.header("Access-Control-Allow-Origin").get(), is(equalTo("*")));
+		});
+	}
+
+	@Test
+	public void reconcileSuggestTypeRequest() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			Result result = route(application, fakeRequest(GET, "/gnd/reconcile/suggest/type?prefix=werk"));
+			assertNotNull(result);
+			assertThat(result.contentType().get(), is(equalTo("application/json")));
+			assertThat(result.header("Access-Control-Allow-Origin").get(), is(equalTo("*")));
+			assertThat(contentAsString(result), containsString("broader"));
 		});
 	}
 


### PR DESCRIPTION
This implements the suggested spec change from https://github.com/reconciliation-api/specs/pull/73

To be used by a client e.g. as in https://github.com/reconciliation-api/testbench/pull/28

(And two minor fixes I encountered while working on that.)

Deployed to test, see new `broader` types e.g. in:

`curl https://test.lobid.org/gnd/reconcile/` (`defaultTypes`)

`curl https://test.lobid.org/gnd/reconcile/suggest/type?prefix=werk`


