### PR TITLE
Catch exceptions to avoid aborting when processing OAI-PMH XML

### DIFF
--- a/app/apps/ConvertBaseline.java
+++ b/app/apps/ConvertBaseline.java
@@ -8,11 +8,13 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
+import java.io.Reader;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.culturegraph.mf.elasticsearch.JsonToElasticsearchBulk;
+import org.culturegraph.mf.flowcontrol.ObjectExceptionCatcher;
 import org.culturegraph.mf.io.FileOpener;
 import org.culturegraph.mf.io.ObjectWriter;
 import org.culturegraph.mf.xml.XmlDecoder;
@@ -42,6 +44,7 @@ public class ConvertBaseline {
 				File out = outFile.isDirectory() ? new File(outFile, new File(file).getName() + ".jsonl") : outFile;
 				final ObjectWriter<String> writer = new ObjectWriter<>(out.getAbsolutePath());
 				opener//
+						.setReceiver(new ObjectExceptionCatcher<Reader>())//
 						.setReceiver(new XmlDecoder())//
 						.setReceiver(splitter)//
 						.setReceiver(encodeJson)//


### PR DESCRIPTION
Triggered by mail from L.Z. on 2022-08-23.

Attempted reindexing updates since 2022-06-13, aborted due to XML processing error on updates for 2022-07-14. With this change, the entry causing the error ([dnb/1262530970](https://d-nb.info/gnd/1262530970/about/lds.rdf)) was skipped, and processing continued.

Opening #321 for the actual processing error and missing entry ([lobid/1262530970](https://lobid.org/gnd/1262530970)).

