### PR TITLE
Handle missing `gndIdentifier` in search result and JSON link

### DIFF
--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -342,7 +342,8 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 		if (responseFormat == null || responseFormat == Accept.Format.JSON_LINES
 				|| format != null && format.contains(":")) {
 			return unsupportedMediaType(views.html.error.render(id, String.format(
-					"Unsupported for single resource: format=%s, accept=%s", format, request().acceptedTypes())));
+					"Unsupported for single resource: format=%s, accept=%s", format,
+					request().acceptedTypes()), allHits()));
 		}
 		String jsonLd = getAuthorityResource(id);
 		if (jsonLd == null) {
@@ -372,7 +373,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 			}
 		} catch (Exception e) {
 			Logger.error("Could not create response", e);
-			return internalServerError(views.html.error.render(id, e.getMessage()));
+			return internalServerError(views.html.error.render(id, e.getMessage(), allHits()));
 		}
 	}
 
@@ -476,7 +477,9 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 		if (responseFormat == null || Stream.of(RdfFormat.values()).map(RdfFormat::getParam)
 				.anyMatch(f -> f.equals(responseFormat.queryParamString))) {
 			return unsupportedMediaType(views.html.error.render(q,
-					String.format("Unsupported for search: format=%s, accept=%s", format, request().acceptedTypes())));
+					String.format("Unsupported for search: format=%s, accept=%s", format,
+							request().acceptedTypes()),
+					allHits()));
 		}
 		String queryString = buildQueryString(q, name, place, subject, publication, date);
 		queryString = (queryString == null || queryString.isEmpty()) ? "*" : queryString;
@@ -507,7 +510,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 		} catch (Throwable t) {
 			String message = t.getMessage() + (t.getCause() != null ? ", cause: " + t.getCause().getMessage() : "");
 			Logger.error("Error: {}", message);
-			return internalServerError(views.html.error.render(q, "Error: " + message));
+			return internalServerError(views.html.error.render(q, "Error: " + message, allHits()));
 		}
 	}
 

--- a/app/models/AuthorityResource.java
+++ b/app/models/AuthorityResource.java
@@ -75,7 +75,7 @@ public class AuthorityResource {
 	}
 
 	public String getId() {
-		return id.substring(id.startsWith(GND_PREFIX) ? GND_PREFIX.length() : RPPD_PREFIX.length());
+		return id.replace(GND_PREFIX, "").replace(RPPD_PREFIX, "");
 	}
 
 	public String getFullId() {

--- a/app/views/error.scala.html
+++ b/app/views/error.scala.html
@@ -1,8 +1,8 @@
 @* Copyright 2015-2018 Fabian Steeg, hbz. Licensed under the EPL 2.0 *@
 
-@(q: String, message: String)
+@(q: String, message: String, allHits: Long)
 
-@main(q, "Error") { 
+@main(q, "Error", allHits) { 
 	<div class="panel panel-danger footer">
 		<div class='panel-heading'>Fehler</div>
 		<div class='panel-body'>@message</div>

--- a/app/views/search.scala.html
+++ b/app/views/search.scala.html
@@ -201,7 +201,7 @@
                  </div>
                  <table class="table table-striped table-condensed">
                  <tr><th /><th /><th /><th /><th /></tr>
-                 @for((doc,i) <- hits; gndId = (doc\"gndIdentifier").as[String]; id = if (gndId.contains("Keine")) (doc\"rppdId").as[String] else gndId) {
+                 @for((doc,i) <- hits; gndId = (doc\"gndIdentifier").asOpt[String].getOrElse("Keine"); id = if (gndId.contains("Keine")) (doc\"rppdId").as[String] else gndId) {
                     @result_short(id,doc,i-1)
                  }
                  </table>


### PR DESCRIPTION
See https://jira.hbz-nrw.de/browse/RPB-153.

Problem in prod:

- Result list: https://rppd.lobid.org/search?q=NOT+_exists_%3AgndIdentifier
- JSON links e.g. https://rppd.lobid.org/ddf9bc44-a80b-41fe-996d-5a38c041c482

Deployed to test:

- Result list: http://test.rppd.lobid.org/search?q=NOT+_exists_%3AgndIdentifier
- JSON links e.g. http://test.rppd.lobid.org/6277a7fa-4852-49de-91b8-f465491a9f24

(Also fixed wrong person number in footer of search result error page.)