### PR TITLE
Fix country code labels

### DIFF
--- a/conf/countryCode2LabelMap.tsv
+++ b/conf/countryCode2LabelMap.tsv
@@ -1,0 +1,1408 @@
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NG	Nigeria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NG	Nigeria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-KI	Kiribati
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-KI	Kiribati
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-HM	Heard and McDonald Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-HM	Heard und McDonaldinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-EE	Estonia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-EE	Estland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AZ	Azerbaijan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AZ	Aserbaidschan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EG	Egypt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EG	Ägypten
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-JU	Jura
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-JU	Kanton Jura
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD	America
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD	Amerika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BE	Belgien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BE	Belgium
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ER	Eritrea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ER	Eritrea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-SB	Salomonen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-SB	Solomon Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-MIUM	Midway Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-MIUM	Midway Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SH	Sankt Helena
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SH	Saint Helena
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BS	Bahamas
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BS	Bahamas
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XZ	Imaginary places
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XZ	Fiktive Geografika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SI	Slowenien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SI	Slovenia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PA	Panama
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PA	Panama
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NW	Nidwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NW	Kanton Nidwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZM	Sambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZM	Zambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RHZW	Southern Rhodesia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RHZW	Simbabwe (Rhodesien)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FR	France
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FR	Frankreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CI	Côte d'Ivoire
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CI	Elfenbeinküste
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PT	Portugal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PT	Portugal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CK	Cookinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CK	Cook Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TC	Turks and Caicos Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TC	Turks- und Caicos-Inseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CU	Kuba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CU	Cuba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BL	Basel-Landschaft
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BL	Kanton Basel-Landschaft
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MT	Malta
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MT	Malta
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-QA	Katar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-QA	Qatar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TL	East Timor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TL	Osttimor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-9	Vienna
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-9	Wien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TO	Tonga
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TO	Tonga
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GI	Gibraltar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GI	Gibraltar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TW	Taiwan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TW	Taiwan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#NTHH	Neutral Zone (-1993)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#NTHH	Neutrale Zone (-1993)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZG	Zug
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZG	Kanton Zug
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GS	South Georgia and the South Sandwich Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GS	Südgeorgien und Südliche Sandwichinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KM	Komoren
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KM	Comoros
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KN	Saint Kitts-Nevis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KN	Saint Kitts und Nevis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-AQ	Antarctica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-AQ	Antarktika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NZ	New Zealand
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NZ	Neuseeland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TG	Thurgau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TG	Kanton Thurgau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT	Austria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT	Österreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HN	Honduras
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HN	Honduras
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AW	Aruba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AW	Aruba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KW	Kuwait
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KW	Kuwait
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-EC	Ecuador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-EC	Ecuador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GE	Geneva
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GE	Kanton Genf
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KY	Cayman Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KY	Cayman Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YE	Jemen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YE	Yemen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VG	British Virgin Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VG	Jungferninseln (Großbritannien)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XU	Byzantine Empire
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XU	Byzantinisches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IM	Man (Insel)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IM	Isle of Man
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IN	India
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IN	Indien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SR	Suriname
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SR	Surinam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NHVU	New Hebrides
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NHVU	Neue Hebriden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CD	Congo (Democratic Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CD	Kongo (Demokratische Republik)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MD	Moldawien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MD	Moldova
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PR	Puerto Rico
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PR	Puerto Rico
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MH	Marshallinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MH	Marshall Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN	China
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN	China
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-NQAQ	Queen Maud Land
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-NQAQ	Königin-Maud-Land
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-TF	Africa, Southern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-TF	Französische Südgebiete
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-4	Upper Austria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-4	Oberösterreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-GE	Georgia (Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-GE	Georgien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JP	Japan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JP	Japan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TR	Turkey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TR	Türkei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TT	Trinidad und Tobago
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TT	Trinidad and Tobago
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GQ	Äquatorialguinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GQ	Equatorial Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PZPA	Panamakanalzone
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PZPA	Panama
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-NI	Nicaragua
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-NI	Nicaragua
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AD	Andorra
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AD	Andorra
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AE	Vereinigte Arabische Emirate
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AE	United Arab Emirates
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AG	Antigua und Barbuda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AG	Antigua and Barbuda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KG	Kirgisien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KG	Kyrgyzstan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AR	Argentina
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AR	Argentinien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KR	Südkorea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KR	Korea (South)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NW	North Rhine-Westphalia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NW	Nordrhein-Westfalen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EH	Westsahara
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EH	Western Sahara
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RS	Serbien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RS	Serbia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HT	Haiti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HT	Haiti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE	Australia, Oceania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE	Australien, Ozeanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XP	International Organizations
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XP	Internationale Staatengemeinschaften, internationale Organisationen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SL	Sierra Leone
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SL	Sierra Leone
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IS	Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IS	Iceland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PK	Pakistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PK	Pakistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BW	Baden-Württemberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BW	Baden-Württemberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MA	Marokko
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MA	Morocco
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PM	Saint Pierre and Miquelon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PM	Saint-Pierre-et-Miquelon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PCHH	Oceania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PCHH	Ozeanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH	Switzerland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH	Schweiz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ML	Mali
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ML	Mali
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-JM	Jamaika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-JM	Jamaica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TM	Turkmenistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TM	Turkmenistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GA	Gabun
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GA	Gabon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MV	Malediven
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MV	Maldives
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MW	Malawi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MW	Malawi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MX	Mexico
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MX	Mexiko
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TN	Tunisia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TN	Tunesien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZH	Zürich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZH	Kanton Zürich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NL	Niederlande
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NL	Netherlands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GW	Guinea-Bissau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GW	Guinea-Bissau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DM	Dominica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DM	Dominica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SUHH	Soviet Union
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SUHH	Sowjetunion
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DXDE	Germany
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DXDE	Deutschland, Deutsches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-UZ	Uzbekistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-UZ	Usbekistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BA	Bosnien-Herzegowina
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BA	Bosnia and Hercegovina
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CTKI	Canton and Enderbury
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CTKI	Canton und Enderbury (-1984)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK	Atlantic Ocean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK	Atlantischer Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-ID	Indonesia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-ID	Indonesien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BO	Bolivia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BO	Bolivien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SE	Schweden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SE	Sweden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XV	Ottoman Empire
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XV	Osmanisches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-BV	Bouvetinsel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-BV	Bouvet Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BZ	Belize
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BZ	Belize
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ME	Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ME	Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MG	Madagaskar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MG	Madagascar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSXX	Serbia and Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSXX	Serbien-Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-JE	Jersey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-JE	Jersey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-BQAQ	British Antarctic Territory
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-BQAQ	Britisches Antarktis-Territorium
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TH	Thailand
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TH	Thailand
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MR	Mauretanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MR	Mauritania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MS	Montserrat
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MS	Montserrat (Insel)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-5	Salzburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-5	Land Salzburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TK	Tokelau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TK	Tokelau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CY	Zypern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CY	Cyprus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BS	Basel-Stadt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BS	Kanton Basel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-LU	Luzern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-LU	Kanton Luzern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-MV	Mecklenburg-Vorpommern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-MV	Mecklenburg-Vorpommern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TV	Tuvalu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TV	Tuvalu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE	Germany
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE	Deutschland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AAAT	Austria (-12.11.1918)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AAAT	Österreich (-12.11.1918)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SKIN	Sikkim
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SKIN	Sikkim
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AF	Afghanistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AF	Afghanistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KH	Cambodia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KH	Kambodscha
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#ZZ	Country unknown
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#ZZ	Land unbekannt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AS	Amerikanisch-Samoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AS	American Samoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HB	Bremen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HB	Bremen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HR	Kroatien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HR	Croatia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GL	Glarus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GL	Kanton Glarus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VC	Saint Vincent and the Grenadines
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VC	Saint Vincent and the Grenadines
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ET	Äthiopien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ET	Ethiopia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BG	Bulgaria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BG	Bulgarien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BH	Bahrain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BH	Bahrain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BI	Burundi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BI	Burundi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LI	Liechtenstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LI	Liechtenstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BB	Brandenburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BB	Brandenburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SA	Saudi-Arabien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SA	Saudi Arabia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XQ	World
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XQ	Gesamte Welt, Übrige Welt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SJ	Svalbard und Jan Mayen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SJ	Svalbard and Jan Mayen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LT	Lithuania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LT	Litauen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SK	Slovakia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SK	Slowakei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FI	Finland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FI	Finnland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT	Italy
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT	Italien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CA	Canada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CA	Kanada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FM	Mikronesien (Staat)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FM	Micronesia (Federated States)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WF	Wallis and Futuna
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WF	Wallis und Futuna
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BUMM	Burma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BUMM	Burma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CL	Chile
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CL	Chile
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MK	Nordmazedonien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MK	North Macedonia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TD	Chad
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TD	Tschad
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PY	Paraguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PY	Paraguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CV	Cape Verde
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CV	Kap Verde
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CX	Christmas Island (Indian Ocean)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CX	Christmas Island (Australien)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SG	St. Gallen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SG	Kanton Sankt Gallen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-TH	Thuringia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-TH	Thüringen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GM	Gambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GM	Gambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TZ	Tansania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TZ	Tanzania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NF	Norfolk-Insel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NF	Norfolk Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DK	Denmark
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DK	Dänemark
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GY	Guyana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GY	Guyana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YDYE	Yemen (Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YDYE	Jemen (Demokratische Volksrepublik)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TI	Ticino
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TI	Kanton Tessin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RO	Rumänien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RO	Romania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HH	Hamburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HH	Hamburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA	Europe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA	Europa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GR	Grisons
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GR	Kanton Graubünden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL	Indian Ocean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL	Indischer Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VI	Jungferninseln (USA)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VI	Virgin Islands of the United States
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BN	Brunei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BN	Brunei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AG	Aargau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AG	Kanton Aargau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SG	Singapore
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SG	Singapur
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XW	Palestinian Arabs
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XW	Palästinenser in Geschichte und Gegenwart
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-VU	Vanuatu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-VU	Vanuatu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AIDJ	Djibouti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AIDJ	Französisches Afar- und Issa-Territorium
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-IO	Britisches Territorium im Indischen Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-IO	British Indian Ocean Territory
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AR	Appenzell Ausserrhoden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AR	Kanton Appenzell (Ausserrhoden)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SS	South Sudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SS	Südsudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SL	Saarland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SL	Saarland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CF	Zentralafrikanische Republik
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CF	Central African Republic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CR	Costa Rica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CR	Costa Rica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-6	Styria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-6	Steiermark
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CZ	Tschechische Republik
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CZ	Czech Republic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GH	Ghana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GH	Ghana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GT	Guatemala
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GT	Guatemala
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GU	Guam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GU	Guam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AI	Anguilla
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AI	Anguilla
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-AU	Australia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-AU	Australien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RU	Russland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RU	Russia (Federation)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-VA	Vatikanstadt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-VA	Vatican City
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RW	Rwanda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RW	Ruanda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-RP	Rhineland-Palatinate
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-RP	Rheinland-Pfalz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ES	Spanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ES	Spain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BJ	Benin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BJ	Benin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LK	Sri Lanka
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LK	Sri Lanka
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XR	Orient
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XR	Alter Orient
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SC	Seychellen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SC	Seychelles
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BT	Bhutan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BT	Bhutan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LU	Luxembourg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LU	Luxemburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SN	Senegal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SN	Senegal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BY	Bavaria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BY	Bayern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PL	Polen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PL	Poland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CC	Kokosinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CC	Cocos (Keeling) Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MM	Birma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MM	Burma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-1	Burgenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-1	Burgenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MP	Northern Mariana Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MP	Nördliche Marianen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-FQHH	Terres australes et antarctiques françaises
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-FQHH	Terres Australes et Antarctiques Françaises
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZRCD	Congo (Democratic Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZRCD	Kongo (Demokratische Republik)(Zaire)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-WKUM	Wake Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-WKUM	Wake Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GD	Grenada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GD	Grenada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SH	Schaffhausen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SH	Kanton Schaffhausen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VS	Valais
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VS	Kanton Wallis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GN	Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GN	Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NE	Niger
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NE	Niger
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PUUM	American Territory in the Pacific (-1986)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PUUM	Amerikanisches Territorium im Pazifik (-1986)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-HVBF	Burkina Faso
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-HVBF	Burkina Faso (Obervolta)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DO	Dominican Republic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DO	Dominikanische Republik
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KE	Kenya
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KE	Kenia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-UG	Uganda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-UG	Uganda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NR	Nauru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NR	Nauru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NI	Lower Saxony
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NI	Niedersachsen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AL	Albanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AL	Albania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AM	Armenien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AM	Armenia (Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-RE	Réunion
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-RE	Réunion
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-US	United States
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-US	USA
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KZ	Kasachstan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KZ	Kazakhstan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB	Asia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB	Asien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BD	Bangladesh
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BD	Bangladesch
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VDVN	Südvietnam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VDVN	Vietnam (South)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM	Pacific Ocean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM	Pazifischer Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-YT	Mayotte
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-YT	Mayotte
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IE	Irland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IE	Ireland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LR	Liberia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LR	Liberia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XX	Arab Countries
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XX	Arabische Staaten, Araber
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BY	Belarus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BY	Weißrussland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IQ	Iraq
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IQ	Irak
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PH	Philippinen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PH	Philippines
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ST	Sao Tomé und Príncipe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ST	Sao Tome and Principe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FO	Färöer
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FO	Faroe Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CG	Kongo (Republik)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CG	Congo (Brazzaville)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-OW	Obwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-OW	Kanton Obwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN-54	Tibet (China)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN-54	Tibet
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TJ	Tadschikistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TJ	Tajikistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-7	Tyrol
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-7	Tirol
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GG	Guernsey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GG	Guernsey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GR	Greece
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GR	Griechenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-ANHH	Niederländische Antillen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-ANHH	Netherlands Antilles
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-NU	Niue
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-NU	Niue
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-UY	Uruguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-UY	Uruguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LA	Laos
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LA	Laos
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XH	Arctic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XH	Arktis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-LC	Saint Lucia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-LC	Saint Lucia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NE	Neuchâtel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NE	Kanton Neuenburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VE	Venezuela
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VE	Venezuela
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BL	Saint Barthélemy
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BL	Saint-Barthélemy (Kleine Antillen)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XS	Greece
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XS	Griechenland (Altertum)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VN	Vietnam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VN	Vietnam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SD	Sudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SD	Sudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IL	Israel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IL	Israel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LV	Latvia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LV	Lettland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-UR	Uri
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-UR	Kanton Uri
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SM	San Marino
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SM	San Marino
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PE	Peru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PE	Peru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SO	Somalia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SO	Somalia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PF	French Polynesia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PF	Französisch-Polynesien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SH	Schleswig-Holstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SH	Schleswig-Holstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GEHH	Gilbert Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GEHH	Gilbertinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PN	Pitcairn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PN	Pitcairn Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SY	Syria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SY	Syrien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SZ	Swaziland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SZ	Swasiland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DDDE	Germany East
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DDDE	Deutschland (DDR)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CM	Cameroon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CM	Kamerun
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BE	Bern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BE	Kanton Bern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MN	Mongolei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MN	Mongolia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-2	Carinthia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-2	Kärnten
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSHH	Czechoslovakia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSHH	Tschechoslowakei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WS	Samoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WS	Westsamoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GB	Großbritannien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GB	Great Britain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MY	Malaysia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MY	Malaysia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MZ	Mozambique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MZ	Moçambique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GL	Grönland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GL	Greenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GP	Guadeloupe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GP	Guadeloupe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NO	Norway
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NO	Norwegen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-FR	Fribourg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-FR	Kanton Freiburg (Üechtland)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-NP	Nepal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-NP	Nepal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT-32	Trentino-Alto Adige Italy
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT-32	Trentino-Südtirol
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DYBJ	Dahomey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DYBJ	Dahomey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AO	Angola
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AO	Angola
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DZ	Algeria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DZ	Algerien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KP	Korea (North)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KP	Nordkorea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AX	Ǻland Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AX	Ålandinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC	Africa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC	Afrika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BF	Burkina Faso
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BF	Burkina Faso
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XN	Outer Space
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XN	Extraterrestrika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BR	Brazil
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BR	Brasilien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AI	Appenzell Innerrhoden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AI	Kanton Appenzell (Innerrhoden)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LS	Lesotho
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LS	Lesotho
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XY	Jews
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XY	Juden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZA	Südafrika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZA	South Africa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IR	Iran
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IR	Iran
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FJ	Fidschi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FJ	Fiji
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SV	El Salvador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SV	El Salvador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SN	Saxony
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SN	Sachsen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-YUCS	Föderative Republik Jugoslawien; Jugoslawien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-YUCS	Yugoslavia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VD	Vaud
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VD	Kanton Waadt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PW	Palauinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PW	Palau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZW	Simbabwe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZW	Zimbabwe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MU	Mauritius
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MU	Mauritius
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-8	Vorarlberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-8	Vorarlberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NA	Namibia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NA	Namibia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NC	New Caledonia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NC	Neukaledonien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SO	Solothurn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SO	Kanton Solothurn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DJ	Dschibuti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DJ	Djibouti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-JTUM	Johnston Atoll
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-JTUM	Johnston-Inseln (-1986)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-UA	Ukraine
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-UA	Ukraine
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SZ	Schwyz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SZ	Kanton Schwyz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-UM	Amerikanische Überseeinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-UM	United States Misc. Pacific Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-HK	Hong Kong
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-HK	Hongkong
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HE	Hesse
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HE	Hessen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HU	Hungary
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HU	Ungarn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BB	Barbados
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BB	Barbados
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LB	Lebanon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LB	Libanon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-OM	Oman
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-OM	Oman
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI	Antarktis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI	Antarctic Ocean/Antarctica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BM	Bermudainseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BM	Bermuda Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BE	Berlin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BE	Berlin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XT	Rome
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XT	Römisches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BW	Botswana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BW	Botswana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LY	Libya
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LY	Libyen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PG	Papua New Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PG	Papua-Neuguinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FK	Falkland Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FK	Falklandinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MC	Monaco
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MC	Monaco
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MF	Saint-Martin (Kleine Antillen, Nord)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MF	Saint Martin, Northern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-ST	Saxony-Anhalt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-ST	Sachsen-Anhalt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CO	Kolumbien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CO	Colombia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MO	Macau (China : Special Administrative Region)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MO	Macau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MQ	Martinique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MQ	Martinique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-3	Lower Austria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-3	Niederösterreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TG	Togo
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TG	Togo
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JO	Jordan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JO	Jordanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GF	French Guiana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GF	Französisch-Guayana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TPTL	East Timor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TPTL	Osttimor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NG	Nigeria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NG	Nigeria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-KI	Kiribati
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-KI	Kiribati
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-HM	Heard and McDonald Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-HM	Heard und McDonaldinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-EE	Estonia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-EE	Estland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AZ	Azerbaijan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AZ	Aserbaidschan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EG	Egypt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EG	Ägypten
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-JU	Jura
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-JU	Kanton Jura
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD	America
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD	Amerika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BE	Belgien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BE	Belgium
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ER	Eritrea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ER	Eritrea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-SB	Salomonen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-SB	Solomon Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-MIUM	Midway Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-MIUM	Midway Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SH	Sankt Helena
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SH	Saint Helena
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BS	Bahamas
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BS	Bahamas
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XZ	Imaginary places
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XZ	Fiktive Geografika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SI	Slowenien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SI	Slovenia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PA	Panama
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PA	Panama
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NW	Nidwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NW	Kanton Nidwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZM	Sambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZM	Zambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RHZW	Southern Rhodesia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RHZW	Simbabwe (Rhodesien)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FR	France
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FR	Frankreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CI	Côte d'Ivoire
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CI	Elfenbeinküste
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PT	Portugal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PT	Portugal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CK	Cookinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CK	Cook Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TC	Turks and Caicos Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TC	Turks- und Caicos-Inseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CU	Kuba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CU	Cuba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BL	Basel-Landschaft
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BL	Kanton Basel-Landschaft
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MT	Malta
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MT	Malta
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-QA	Katar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-QA	Qatar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TL	East Timor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TL	Osttimor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-9	Vienna
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-9	Wien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TO	Tonga
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TO	Tonga
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GI	Gibraltar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GI	Gibraltar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TW	Taiwan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TW	Taiwan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#NTHH	Neutral Zone (-1993)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#NTHH	Neutrale Zone (-1993)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZG	Zug
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZG	Kanton Zug
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GS	South Georgia and the South Sandwich Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GS	Südgeorgien und Südliche Sandwichinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KM	Komoren
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KM	Comoros
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KN	Saint Kitts-Nevis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KN	Saint Kitts und Nevis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-AQ	Antarctica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-AQ	Antarktika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NZ	New Zealand
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NZ	Neuseeland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TG	Thurgau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TG	Kanton Thurgau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT	Austria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT	Österreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HN	Honduras
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HN	Honduras
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AW	Aruba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AW	Aruba
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KW	Kuwait
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KW	Kuwait
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-EC	Ecuador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-EC	Ecuador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GE	Geneva
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GE	Kanton Genf
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KY	Cayman Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KY	Cayman Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YE	Jemen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YE	Yemen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VG	British Virgin Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VG	Jungferninseln (Großbritannien)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XU	Byzantine Empire
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XU	Byzantinisches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IM	Man (Insel)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IM	Isle of Man
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IN	India
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IN	Indien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SR	Suriname
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SR	Surinam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NHVU	New Hebrides
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NHVU	Neue Hebriden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CD	Congo (Democratic Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CD	Kongo (Demokratische Republik)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MD	Moldawien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MD	Moldova
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PR	Puerto Rico
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PR	Puerto Rico
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MH	Marshallinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MH	Marshall Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN	China
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN	China
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-NQAQ	Queen Maud Land
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-NQAQ	Königin-Maud-Land
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-TF	Africa, Southern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-TF	Französische Südgebiete
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-4	Upper Austria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-4	Oberösterreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-GE	Georgia (Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-GE	Georgien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JP	Japan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JP	Japan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TR	Turkey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TR	Türkei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TT	Trinidad und Tobago
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TT	Trinidad and Tobago
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GQ	Äquatorialguinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GQ	Equatorial Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PZPA	Panamakanalzone
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PZPA	Panama
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-NI	Nicaragua
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-NI	Nicaragua
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AD	Andorra
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AD	Andorra
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AE	Vereinigte Arabische Emirate
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AE	United Arab Emirates
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AG	Antigua und Barbuda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AG	Antigua and Barbuda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KG	Kirgisien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KG	Kyrgyzstan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AR	Argentina
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AR	Argentinien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KR	Südkorea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KR	Korea (South)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NW	North Rhine-Westphalia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NW	Nordrhein-Westfalen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EH	Westsahara
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EH	Western Sahara
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RS	Serbien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RS	Serbia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HT	Haiti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HT	Haiti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE	Australia, Oceania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE	Australien, Ozeanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XP	International Organizations
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XP	Internationale Staatengemeinschaften, internationale Organisationen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SL	Sierra Leone
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SL	Sierra Leone
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IS	Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IS	Iceland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PK	Pakistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PK	Pakistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BW	Baden-Württemberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BW	Baden-Württemberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MA	Marokko
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MA	Morocco
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PM	Saint Pierre and Miquelon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PM	Saint-Pierre-et-Miquelon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PCHH	Oceania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PCHH	Ozeanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH	Switzerland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH	Schweiz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ML	Mali
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ML	Mali
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-JM	Jamaika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-JM	Jamaica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TM	Turkmenistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TM	Turkmenistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GA	Gabun
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GA	Gabon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MV	Malediven
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MV	Maldives
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MW	Malawi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MW	Malawi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MX	Mexico
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MX	Mexiko
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TN	Tunisia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TN	Tunesien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZH	Zürich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZH	Kanton Zürich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NL	Niederlande
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NL	Netherlands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GW	Guinea-Bissau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GW	Guinea-Bissau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DM	Dominica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DM	Dominica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SUHH	Soviet Union
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SUHH	Sowjetunion
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DXDE	Germany
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DXDE	Deutschland, Deutsches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-UZ	Uzbekistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-UZ	Usbekistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BA	Bosnien-Herzegowina
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BA	Bosnia and Hercegovina
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CTKI	Canton and Enderbury
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CTKI	Canton und Enderbury (-1984)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK	Atlantic Ocean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK	Atlantischer Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-ID	Indonesia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-ID	Indonesien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BO	Bolivia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BO	Bolivien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SE	Schweden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SE	Sweden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XV	Ottoman Empire
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XV	Osmanisches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-BV	Bouvetinsel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-BV	Bouvet Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BZ	Belize
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BZ	Belize
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ME	Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ME	Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MG	Madagaskar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MG	Madagascar
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSXX	Serbia and Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSXX	Serbien-Montenegro
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-JE	Jersey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-JE	Jersey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-BQAQ	British Antarctic Territory
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-BQAQ	Britisches Antarktis-Territorium
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TH	Thailand
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TH	Thailand
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MR	Mauretanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MR	Mauritania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MS	Montserrat
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MS	Montserrat (Insel)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-5	Salzburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-5	Land Salzburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TK	Tokelau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TK	Tokelau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CY	Zypern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CY	Cyprus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BS	Basel-Stadt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BS	Kanton Basel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-LU	Luzern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-LU	Kanton Luzern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-MV	Mecklenburg-Vorpommern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-MV	Mecklenburg-Vorpommern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TV	Tuvalu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TV	Tuvalu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE	Germany
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE	Deutschland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AAAT	Austria (-12.11.1918)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AAAT	Österreich (-12.11.1918)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SKIN	Sikkim
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SKIN	Sikkim
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AF	Afghanistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AF	Afghanistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KH	Cambodia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KH	Kambodscha
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#ZZ	Country unknown
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#ZZ	Land unbekannt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AS	Amerikanisch-Samoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AS	American Samoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HB	Bremen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HB	Bremen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HR	Kroatien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HR	Croatia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GL	Glarus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GL	Kanton Glarus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VC	Saint Vincent and the Grenadines
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VC	Saint Vincent and the Grenadines
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ET	Äthiopien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ET	Ethiopia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BG	Bulgaria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BG	Bulgarien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BH	Bahrain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BH	Bahrain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BI	Burundi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BI	Burundi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LI	Liechtenstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LI	Liechtenstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BB	Brandenburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BB	Brandenburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SA	Saudi-Arabien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SA	Saudi Arabia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XQ	World
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XQ	Gesamte Welt, Übrige Welt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SJ	Svalbard und Jan Mayen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SJ	Svalbard and Jan Mayen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LT	Lithuania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LT	Litauen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SK	Slovakia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SK	Slowakei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FI	Finland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FI	Finnland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT	Italy
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT	Italien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CA	Canada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CA	Kanada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FM	Mikronesien (Staat)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FM	Micronesia (Federated States)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WF	Wallis and Futuna
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WF	Wallis und Futuna
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BUMM	Burma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BUMM	Burma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CL	Chile
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CL	Chile
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MK	Nordmazedonien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MK	North Macedonia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TD	Chad
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TD	Tschad
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PY	Paraguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PY	Paraguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CV	Cape Verde
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CV	Kap Verde
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CX	Christmas Island (Indian Ocean)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CX	Christmas Island (Australien)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SG	St. Gallen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SG	Kanton Sankt Gallen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-TH	Thuringia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-TH	Thüringen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GM	Gambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GM	Gambia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TZ	Tansania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TZ	Tanzania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NF	Norfolk-Insel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NF	Norfolk Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DK	Denmark
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DK	Dänemark
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GY	Guyana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GY	Guyana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YDYE	Yemen (Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YDYE	Jemen (Demokratische Volksrepublik)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TI	Ticino
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TI	Kanton Tessin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RO	Rumänien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RO	Romania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HH	Hamburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HH	Hamburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA	Europe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA	Europa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GR	Grisons
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GR	Kanton Graubünden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL	Indian Ocean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL	Indischer Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VI	Jungferninseln (USA)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VI	Virgin Islands of the United States
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BN	Brunei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BN	Brunei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AG	Aargau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AG	Kanton Aargau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SG	Singapore
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SG	Singapur
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XW	Palestinian Arabs
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XW	Palästinenser in Geschichte und Gegenwart
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-VU	Vanuatu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-VU	Vanuatu
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AIDJ	Djibouti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AIDJ	Französisches Afar- und Issa-Territorium
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-IO	Britisches Territorium im Indischen Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-IO	British Indian Ocean Territory
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AR	Appenzell Ausserrhoden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AR	Kanton Appenzell (Ausserrhoden)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SS	South Sudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SS	Südsudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SL	Saarland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SL	Saarland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CF	Zentralafrikanische Republik
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CF	Central African Republic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CR	Costa Rica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CR	Costa Rica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-6	Styria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-6	Steiermark
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CZ	Tschechische Republik
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CZ	Czech Republic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GH	Ghana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GH	Ghana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GT	Guatemala
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GT	Guatemala
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GU	Guam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GU	Guam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AI	Anguilla
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AI	Anguilla
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-AU	Australia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-AU	Australien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RU	Russland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RU	Russia (Federation)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-VA	Vatikanstadt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-VA	Vatican City
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RW	Rwanda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RW	Ruanda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-RP	Rhineland-Palatinate
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-RP	Rheinland-Pfalz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ES	Spanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ES	Spain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BJ	Benin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BJ	Benin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LK	Sri Lanka
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LK	Sri Lanka
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XR	Orient
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XR	Alter Orient
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SC	Seychellen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SC	Seychelles
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BT	Bhutan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BT	Bhutan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LU	Luxembourg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LU	Luxemburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SN	Senegal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SN	Senegal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BY	Bavaria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BY	Bayern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PL	Polen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PL	Poland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CC	Kokosinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CC	Cocos (Keeling) Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MM	Birma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MM	Burma
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-1	Burgenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-1	Burgenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MP	Northern Mariana Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MP	Nördliche Marianen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-FQHH	Terres australes et antarctiques françaises
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-FQHH	Terres Australes et Antarctiques Françaises
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZRCD	Congo (Democratic Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZRCD	Kongo (Demokratische Republik)(Zaire)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-WKUM	Wake Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-WKUM	Wake Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GD	Grenada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GD	Grenada
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SH	Schaffhausen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SH	Kanton Schaffhausen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VS	Valais
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VS	Kanton Wallis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GN	Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GN	Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NE	Niger
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NE	Niger
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PUUM	American Territory in the Pacific (-1986)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PUUM	Amerikanisches Territorium im Pazifik (-1986)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-HVBF	Burkina Faso
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-HVBF	Burkina Faso (Obervolta)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DO	Dominican Republic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DO	Dominikanische Republik
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KE	Kenya
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KE	Kenia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-UG	Uganda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-UG	Uganda
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NR	Nauru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NR	Nauru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NI	Lower Saxony
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NI	Niedersachsen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AL	Albanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AL	Albania
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AM	Armenien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AM	Armenia (Republic)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-RE	Réunion
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-RE	Réunion
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-US	United States
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-US	USA
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KZ	Kasachstan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KZ	Kazakhstan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB	Asia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB	Asien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BD	Bangladesh
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BD	Bangladesch
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VDVN	Südvietnam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VDVN	Vietnam (South)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM	Pacific Ocean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM	Pazifischer Ozean
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-YT	Mayotte
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-YT	Mayotte
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IE	Irland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IE	Ireland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LR	Liberia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LR	Liberia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XX	Arab Countries
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XX	Arabische Staaten, Araber
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BY	Belarus
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BY	Weißrussland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IQ	Iraq
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IQ	Irak
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PH	Philippinen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PH	Philippines
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ST	Sao Tomé und Príncipe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ST	Sao Tome and Principe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FO	Färöer
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FO	Faroe Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CG	Kongo (Republik)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CG	Congo (Brazzaville)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-OW	Obwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-OW	Kanton Obwalden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN-54	Tibet (China)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN-54	Tibet
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TJ	Tadschikistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TJ	Tajikistan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-7	Tyrol
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-7	Tirol
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GG	Guernsey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GG	Guernsey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GR	Greece
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GR	Griechenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-ANHH	Niederländische Antillen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-ANHH	Netherlands Antilles
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-NU	Niue
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-NU	Niue
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-UY	Uruguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-UY	Uruguay
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LA	Laos
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LA	Laos
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XH	Arctic
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XH	Arktis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-LC	Saint Lucia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-LC	Saint Lucia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NE	Neuchâtel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NE	Kanton Neuenburg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VE	Venezuela
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VE	Venezuela
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BL	Saint Barthélemy
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BL	Saint-Barthélemy (Kleine Antillen)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XS	Greece
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XS	Griechenland (Altertum)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VN	Vietnam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VN	Vietnam
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SD	Sudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SD	Sudan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IL	Israel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IL	Israel
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LV	Latvia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LV	Lettland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-UR	Uri
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-UR	Kanton Uri
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SM	San Marino
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SM	San Marino
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PE	Peru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PE	Peru
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SO	Somalia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SO	Somalia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PF	French Polynesia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PF	Französisch-Polynesien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SH	Schleswig-Holstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SH	Schleswig-Holstein
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GEHH	Gilbert Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GEHH	Gilbertinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PN	Pitcairn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PN	Pitcairn Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SY	Syria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SY	Syrien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SZ	Swaziland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SZ	Swasiland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DDDE	Germany East
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DDDE	Deutschland (DDR)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CM	Cameroon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CM	Kamerun
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BE	Bern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BE	Kanton Bern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MN	Mongolei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MN	Mongolia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-2	Carinthia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-2	Kärnten
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSHH	Czechoslovakia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSHH	Tschechoslowakei
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WS	Samoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WS	Westsamoa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GB	Großbritannien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GB	Great Britain
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MY	Malaysia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MY	Malaysia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MZ	Mozambique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MZ	Moçambique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GL	Grönland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GL	Greenland
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GP	Guadeloupe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GP	Guadeloupe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NO	Norway
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NO	Norwegen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-FR	Fribourg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-FR	Kanton Freiburg (Üechtland)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-NP	Nepal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-NP	Nepal
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT-32	Trentino-Alto Adige Italy
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT-32	Trentino-Südtirol
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DYBJ	Dahomey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DYBJ	Dahomey
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AO	Angola
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AO	Angola
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DZ	Algeria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DZ	Algerien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KP	Korea (North)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KP	Nordkorea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AX	Ǻland Island
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AX	Ålandinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC	Africa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC	Afrika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BF	Burkina Faso
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BF	Burkina Faso
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XN	Outer Space
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XN	Extraterrestrika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BR	Brazil
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BR	Brasilien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AI	Appenzell Innerrhoden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AI	Kanton Appenzell (Innerrhoden)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LS	Lesotho
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LS	Lesotho
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XY	Jews
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XY	Juden
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZA	Südafrika
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZA	South Africa
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IR	Iran
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IR	Iran
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FJ	Fidschi
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FJ	Fiji
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SV	El Salvador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SV	El Salvador
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SN	Saxony
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SN	Sachsen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-YUCS	Föderative Republik Jugoslawien; Jugoslawien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-YUCS	Yugoslavia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VD	Vaud
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VD	Kanton Waadt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PW	Palauinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PW	Palau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZW	Simbabwe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZW	Zimbabwe
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MU	Mauritius
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MU	Mauritius
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-8	Vorarlberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-8	Vorarlberg
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NA	Namibia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NA	Namibia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NC	New Caledonia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NC	Neukaledonien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SO	Solothurn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SO	Kanton Solothurn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DJ	Dschibuti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DJ	Djibouti
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-JTUM	Johnston Atoll
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-JTUM	Johnston-Inseln (-1986)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-UA	Ukraine
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-UA	Ukraine
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SZ	Schwyz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SZ	Kanton Schwyz
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-UM	Amerikanische Überseeinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-UM	United States Misc. Pacific Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-HK	Hong Kong
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-HK	Hongkong
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HE	Hesse
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HE	Hessen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HU	Hungary
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HU	Ungarn
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BB	Barbados
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BB	Barbados
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LB	Lebanon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LB	Libanon
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-OM	Oman
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-OM	Oman
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI	Antarktis
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI	Antarctic Ocean/Antarctica
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BM	Bermudainseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BM	Bermuda Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BE	Berlin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BE	Berlin
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XT	Rome
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XT	Römisches Reich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BW	Botswana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BW	Botswana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LY	Libya
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LY	Libyen
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PG	Papua New Guinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PG	Papua-Neuguinea
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FK	Falkland Islands
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FK	Falklandinseln
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MC	Monaco
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MC	Monaco
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MF	Saint-Martin (Kleine Antillen, Nord)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MF	Saint Martin, Northern
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-ST	Saxony-Anhalt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-ST	Sachsen-Anhalt
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CO	Kolumbien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CO	Colombia
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MO	Macau (China : Special Administrative Region)
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MO	Macau
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MQ	Martinique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MQ	Martinique
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-3	Lower Austria
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-3	Niederösterreich
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TG	Togo
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TG	Togo
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JO	Jordan
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JO	Jordanien
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GF	French Guiana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GF	Französisch-Guayana
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TPTL	East Timor
+https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TPTL	Osttimor

--- a/conf/createCountryCode2LabelMap.py
+++ b/conf/createCountryCode2LabelMap.py
@@ -1,0 +1,21 @@
+import rdflib
+from rdflib import Graph
+
+g = rdflib.Graph()
+
+g.parse("geographic-area-code_20191015.ttl", format="ttl")
+
+qres = g.query(
+    """
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+    SELECT ?uri ?label
+       WHERE {
+        ?uri a skos:Concept ;
+            skos:prefLabel ?label
+       }""")
+
+with open("countryCode2LabelMap.tsv", "a") as output:
+    for row in qres:
+            output.write("%s\t%s" % row) #  separate ?concept and ?label with tab 
+            output.write("\n") # add a new line delimiter to start new line

--- a/conf/geographic-area-code_20191015.ttl
+++ b/conf/geographic-area-code_20191015.ttl
@@ -1,0 +1,3083 @@
+@prefix cc:    <http://creativecommons.org/ns#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann:  <http://purl.org/vocab/vann/> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2328926> , <https://d-nb.info/gnd/4042300-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/nr> , <http://id.loc.gov/vocabulary/geographicAreas/f-nr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Nigeria"@en , "Nigeria"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Nigeria> , <https://de.wikipedia.org/wiki/Nigeria> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-KI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4030945> , <https://d-nb.info/gnd/4073459-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/pokb> , <http://id.loc.gov/vocabulary/countries/gb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kiribati"@en , "Kiribati"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kiribati> , <https://en.wikipedia.org/wiki/Kiribati> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-HM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4451482-7> , <http://www.geonames.org/1547314> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/i-hm> , <http://id.loc.gov/vocabulary/countries/hm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Heard and McDonald Islands"@en , "Heard und McDonaldinseln"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Heard_Island_and_McDonald_Islands> , <https://de.wikipedia.org/wiki/Heard_und_McDonaldinseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-EE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/453733> , <https://d-nb.info/gnd/4015587-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-er> , <http://id.loc.gov/vocabulary/countries/er> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Estonia"@en , "Estland"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Estland> , <https://en.wikipedia.org/wiki/Estonia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4068887-2> , <http://www.geonames.org/587116> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/aj> , <http://id.loc.gov/vocabulary/geographicAreas/a-aj> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Azerbaijan"@en , "Aserbaidschan"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Azerbaijan> , <https://de.wikipedia.org/wiki/Aserbaidschan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4000556-2> , <http://www.geonames.org/357994> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-ua> , <http://id.loc.gov/vocabulary/countries/ua> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Egypt"@en , "Ägypten"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Egypt> , <https://de.wikipedia.org/wiki/%C3%84gypten> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-JU>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2660207> , <https://d-nb.info/gnd/4029043-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Jura"@en , "Kanton Jura"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Jura> , <https://de.wikipedia.org/wiki/Kanton_Jura> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4001670-5> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "America"@en , "Amerika"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Americas> , <https://de.wikipedia.org/wiki/Amerika> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4005406-8> , <http://www.geonames.org/2802361> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-be> , <http://id.loc.gov/vocabulary/countries/be> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Belgien"@de , "Belgium"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Belgium> , <https://de.wikipedia.org/wiki/Belgien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ER>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/338010> , <https://d-nb.info/gnd/4015278-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ea> , <http://id.loc.gov/vocabulary/geographicAreas/f-ea> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Eritrea"@en , "Eritrea"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Eritrea> , <https://de.wikipedia.org/wiki/Eritrea> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-SB>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2103350> , <https://d-nb.info/gnd/4265796-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bp> , <http://id.loc.gov/vocabulary/geographicAreas/pobp> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Salomonen"@de , "Solomon Islands"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Salomonen> , <https://en.wikipedia.org/wiki/Solomon_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-MIUM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4039148-6> , <http://www.geonames.org/5854943> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xf> , <http://id.loc.gov/vocabulary/geographicAreas/poxf> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Midway Islands"@en , "Midway Islands"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Midway_Islands> , <https://de.wikipedia.org/wiki/Midwayinseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4051605-2> , <http://www.geonames.org/3370751> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xj> , <http://id.loc.gov/vocabulary/geographicAreas/lsxj> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sankt Helena"@de , "Saint Helena"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/St._Helena_(Insel)> , <https://en.wikipedia.org/wiki/Saint_Helena> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4069081-7> , <http://www.geonames.org/3572887> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwbf> , <http://id.loc.gov/vocabulary/countries/bf> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bahamas"@en , "Bahamas"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/The_Bahamas> , <https://de.wikipedia.org/wiki/Bahamas> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XZ>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Imaginary places"@en , "Fiktive Geografika"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Fictional_universe> , <https://de.wikipedia.org/wiki/Fiktives_Universum> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3190538> , <https://d-nb.info/gnd/4055302-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xv> , <http://id.loc.gov/vocabulary/geographicAreas/e-xv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Slowenien"@de , "Slovenia"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Slovenia> , <https://de.wikipedia.org/wiki/Slowenien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3703430> , <https://d-nb.info/gnd/4044445-4> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/nc> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/pn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Panama"@en , "Panama"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Panama> , <https://de.wikipedia.org/wiki/Panama> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NW>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2659471> , <https://d-nb.info/gnd/4062040-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Nidwalden"@en , "Kanton Nidwalden"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Nidwalden> , <https://de.wikipedia.org/wiki/Kanton_Nidwalden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/895949> , <https://d-nb.info/gnd/4076986-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/za> , <http://id.loc.gov/vocabulary/geographicAreas/f-za> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sambia"@de , "Zambia"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Sambia> , <https://en.wikipedia.org/wiki/Zambia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RHZW>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/15632-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Southern Rhodesia"@en , "Simbabwe (Rhodesien)"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4018145-5> , <http://www.geonames.org/3017382> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-fr> , <http://id.loc.gov/vocabulary/countries/fr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "France"@en , "Frankreich"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/France> , <https://de.wikipedia.org/wiki/Frankreich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2287781> , <https://d-nb.info/gnd/4014426-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/iv> , <http://id.loc.gov/vocabulary/geographicAreas/f-iv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Côte d'Ivoire"@en , "Elfenbeinküste"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/C%C3%B4te_d%27Ivoire> , <https://de.wikipedia.org/wiki/Elfenbeink%C3%BCste> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2264397> , <https://d-nb.info/gnd/4046843-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-po> , <http://id.loc.gov/vocabulary/countries/po> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Portugal"@en , "Portugal"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Portugal> , <https://en.wikipedia.org/wiki/Portugal> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4230226-2> , <http://www.geonames.org/1899402> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cw> , <http://id.loc.gov/vocabulary/geographicAreas/pocw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Cookinseln"@de , "Cook Islands"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Cookinseln> , <https://en.wikipedia.org/wiki/Cook_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4285170-1> , <http://www.geonames.org/3576916> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwtc> , <http://id.loc.gov/vocabulary/countries/tc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Turks and Caicos Islands"@en , "Turks- und Caicos-Inseln"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Turks-_und_Caicosinseln> , <https://en.wikipedia.org/wiki/Turks_and_Caicos_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3562981> , <https://d-nb.info/gnd/4033340-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cu> , <http://id.loc.gov/vocabulary/geographicAreas/nwcu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kuba"@de , "Cuba"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kuba> , <https://en.wikipedia.org/wiki/Cuba> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BL>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2661603> , <https://d-nb.info/gnd/4004619-9> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Basel-Landschaft"@en , "Kanton Basel-Landschaft"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Basel-Landschaft> , <https://de.wikipedia.org/wiki/Kanton_Basel-Landschaft> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2562770> , <https://d-nb.info/gnd/4037257-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-mm> , <http://id.loc.gov/vocabulary/countries/mm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Malta"@en , "Malta"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Malta> , <https://de.wikipedia.org/wiki/Malta> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-QA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4029924-7> , <http://www.geonames.org/289688> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/qa> , <http://id.loc.gov/vocabulary/geographicAreas/a-qa> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Katar"@de , "Qatar"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Katar> , <https://en.wikipedia.org/wiki/Qatar> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1966436> , <https://d-nb.info/gnd/4075765-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/em> , <http://id.loc.gov/vocabulary/geographicAreas/a-em> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "East Timor"@en , "Osttimor"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/East_Timor> , <https://de.wikipedia.org/wiki/Osttimor> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-9>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2761367> , <https://d-nb.info/gnd/4066009-6> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Vienna"@en , "Wien"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Vienna> , <https://de.wikipedia.org/wiki/Wien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4032283> , <https://d-nb.info/gnd/4060396-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/to> , <http://id.loc.gov/vocabulary/geographicAreas/poto> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tonga"@en , "Tonga"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Tonga> , <https://de.wikipedia.org/wiki/Tonga> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4020965-9> , <http://www.geonames.org/2411586> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gi> , <http://id.loc.gov/vocabulary/geographicAreas/e-gi> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Gibraltar"@en , "Gibraltar"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Gibraltar> , <https://en.wikipedia.org/wiki/Gibraltar> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4017875-4> , <http://www.geonames.org/1668284> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ch> , <http://id.loc.gov/vocabulary/geographicAreas/a-ch> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Taiwan"@de , "Taiwan"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Republik_China_(Taiwan)> , <https://en.wikipedia.org/wiki/Taiwan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#NTHH>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Neutral Zone (-1993)"@en , "Neutrale Zone (-1993)"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Saudi%E2%80%93Iraqi_neutral_zone> , <https://de.wikipedia.org/wiki/Neutrale_Zone_(Irak)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZG>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2657907> , <https://d-nb.info/gnd/4068064-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Zug"@en , "Kanton Zug"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Zug> , <https://de.wikipedia.org/wiki/Kanton_Zug> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3474415> , <https://d-nb.info/gnd/4451507-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/lsxs> , <http://id.loc.gov/vocabulary/countries/xs> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "South Georgia and the South Sandwich Islands"@en , "Südgeorgien und Südliche Sandwichinseln"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/South_Georgia_and_the_South_Sandwich_Islands> , <https://de.wikipedia.org/wiki/S%C3%BCdgeorgien_und_die_S%C3%BCdlichen_Sandwichinseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4265797-0> , <http://www.geonames.org/921929> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/i-cq> , <http://id.loc.gov/vocabulary/countries/cq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Komoren"@de , "Comoros"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Comoros> , <https://de.wikipedia.org/wiki/Komoren> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3575174> , <https://d-nb.info/gnd/4118251-0> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwxa> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xd> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saint Kitts-Nevis"@en , "Saint Kitts und Nevis"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/St._Kitts_und_Nevis> , <https://en.wikipedia.org/wiki/Saint_Kitts_and_Nevis> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-AQ>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/6697173> , <https://d-nb.info/gnd/4192069-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Antarctica"@en , "Antarktika"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Antarctica> , <https://de.wikipedia.org/wiki/Antarktika> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4041915-0> , <http://www.geonames.org/2186224> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/nz> , <http://id.loc.gov/vocabulary/geographicAreas/u-nz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "New Zealand"@en , "Neuseeland"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Neuseeland> , <https://en.wikipedia.org/wiki/New_Zealand> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TG>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658372> , <https://d-nb.info/gnd/4119605-3> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Thurgau"@en , "Kanton Thurgau"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Thurgau> , <https://de.wikipedia.org/wiki/Kanton_Thurgau> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4043271-3> , <http://www.geonames.org/2782113> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/au> , <http://id.loc.gov/vocabulary/geographicAreas/e-au> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Austria"@en , "Österreich"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/%C3%96sterreich> , <https://en.wikipedia.org/wiki/Austria> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4025814-2> , <http://www.geonames.org/3608932> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ho> , <http://id.loc.gov/vocabulary/geographicAreas/ncho> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Honduras"@en , "Honduras"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Honduras> , <https://de.wikipedia.org/wiki/Honduras> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4079840-9> , <http://www.geonames.org/3577279> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/aw> , <http://id.loc.gov/vocabulary/geographicAreas/nwaw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Aruba"@de , "Aruba"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Aruba> , <https://en.wikipedia.org/wiki/Aruba> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/285570> , <https://d-nb.info/gnd/4073919-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ku> , <http://id.loc.gov/vocabulary/geographicAreas/a-ku> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kuwait"@en , "Kuwait"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Kuwait> , <https://de.wikipedia.org/wiki/Kuwait> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-EC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3658394> , <https://d-nb.info/gnd/4129321-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-ec> , <http://id.loc.gov/vocabulary/countries/ec> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Ecuador"@en , "Ecuador"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Ecuador> , <https://en.wikipedia.org/wiki/Ecuador> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GE>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2660645> , <https://d-nb.info/gnd/4020138-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Geneva"@en , "Kanton Genf"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Geneva> , <https://de.wikipedia.org/wiki/Kanton_Genf> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-KY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3580718> , <https://d-nb.info/gnd/4310479-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cj> , <http://id.loc.gov/vocabulary/geographicAreas/nwcj> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Cayman Islands"@en , "Cayman Islands"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kaimaninseln> , <https://en.wikipedia.org/wiki/Cayman_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/69543> , <https://d-nb.info/gnd/4073009-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ye> , <http://id.loc.gov/vocabulary/geographicAreas/a-ye> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Jemen"@de , "Yemen"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Jemen> , <https://en.wikipedia.org/wiki/Yemen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4063590-9> , <http://www.geonames.org/3577718> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/vb> , <http://id.loc.gov/vocabulary/geographicAreas/nwvb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "British Virgin Islands"@en , "Jungferninseln (Großbritannien)"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/British_Virgin_Islands> , <https://de.wikipedia.org/wiki/Britische_Jungferninseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XU>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4009256-2> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Byzantine Empire"@en , "Byzantinisches Reich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Byzantine_Empire> , <https://de.wikipedia.org/wiki/Byzantinisches_Reich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4027756-2> , <http://www.geonames.org/3042225> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-uk-ui> , <http://id.loc.gov/vocabulary/countries/uik> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Man (Insel)"@de , "Isle of Man"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Isle_of_Man> , <https://en.wikipedia.org/wiki/Isle_of_Man> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1269750> , <https://d-nb.info/gnd/4026722-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ii> , <http://id.loc.gov/vocabulary/countries/ii> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "India"@en , "Indien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Indien> , <https://en.wikipedia.org/wiki/India> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3382998> , <https://d-nb.info/gnd/4058664-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sr> , <http://id.loc.gov/vocabulary/geographicAreas/s-sr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Suriname"@en , "Surinam"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Suriname> , <https://de.wikipedia.org/wiki/Suriname> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NHVU>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/61014-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "New Hebrides"@en , "Neue Hebriden"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/New_Hebrides> , <https://de.wikipedia.org/wiki/Kondominium_Neue_Hebriden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/203312> , <https://d-nb.info/gnd/4067357-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cg> , <http://id.loc.gov/vocabulary/geographicAreas/f-cg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Congo (Democratic Republic)"@en , "Kongo (Demokratische Republik)"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Democratic_Republic_of_the_Congo> , <https://de.wikipedia.org/wiki/Demokratische_Republik_Kongo> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/617790> , <https://d-nb.info/gnd/4039967-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mv> , <http://id.loc.gov/vocabulary/geographicAreas/e-mv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Moldawien"@de , "Moldova"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Moldawien> , <https://en.wikipedia.org/wiki/Moldova> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4566966> , <https://d-nb.info/gnd/4076429-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/pr> , <http://id.loc.gov/vocabulary/geographicAreas/nwpr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Puerto Rico"@en , "Puerto Rico"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Puerto_rico> , <https://de.wikipedia.org/wiki/Puerto_Rico> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2080185> , <https://d-nb.info/gnd/4037700-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xe> , <http://id.loc.gov/vocabulary/geographicAreas/poxe> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Marshallinseln"@de , "Marshall Islands"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Marshall_Islands> , <https://de.wikipedia.org/wiki/Marshallinseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4009937-4> , <http://www.geonames.org/1814991> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-cc> , <http://id.loc.gov/vocabulary/countries/cc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "China"@en , "China"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/China> , <https://en.wikipedia.org/wiki/People%27s_Republic_of_China> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-NQAQ>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4393524-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Queen Maud Land"@en , "Königin-Maud-Land"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Queen_Maud_Land> , <https://de.wikipedia.org/wiki/K%C3%B6nigin-Maud-Land> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-TF>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/1546748> , <https://d-nb.info/gnd/4480857-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Africa, Southern"@en , "Französische Südgebiete"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/French_Southern_and_Antarctic_Lands> , <https://de.wikipedia.org/wiki/Franz%C3%B6sische_S%C3%BCd-_und_Antarktisgebiete> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-4>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2769848> , <https://d-nb.info/gnd/4075560-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Upper Austria"@en , "Oberösterreich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Upper_Austria> , <https://de.wikipedia.org/wiki/Ober%C3%B6sterreich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-GE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/614540> , <https://d-nb.info/gnd/4022406-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gs> , <http://id.loc.gov/vocabulary/geographicAreas/a-gs> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Georgia (Republic)"@en , "Georgien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Georgien> , <https://en.wikipedia.org/wiki/Georgia_%28country%29> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JP>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1861060> , <https://d-nb.info/gnd/4028495-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ja> , <http://id.loc.gov/vocabulary/geographicAreas/a-ja> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Japan"@en , "Japan"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Japan> , <https://en.wikipedia.org/wiki/Japan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4061163-2> , <http://www.geonames.org/298795> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-tu> , <http://id.loc.gov/vocabulary/countries/tu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Turkey"@en , "Türkei"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Turkey> , <https://de.wikipedia.org/wiki/T%C3%BCrkei> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-TT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4060907-8> , <http://www.geonames.org/3573591> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/tr> , <http://id.loc.gov/vocabulary/geographicAreas/nwtr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Trinidad und Tobago"@de , "Trinidad and Tobago"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Trinidad_und_Tobago> , <https://en.wikipedia.org/wiki/Trinidad_and_Tobago> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GQ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4068436-2> , <http://www.geonames.org/2309096> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/eg> , <http://id.loc.gov/vocabulary/geographicAreas/f-eg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Äquatorialguinea"@de , "Equatorial Guinea"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Equatorial_Guinea> , <https://de.wikipedia.org/wiki/%C3%84quatorialguinea> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PZPA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4115837-4> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/countries/pn> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nccz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Panamakanalzone"@de , "Panama"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Panamakanalzone> , <https://en.wikipedia.org/wiki/Panama_Canal_Zone> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-NI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3617476> , <https://d-nb.info/gnd/4042050-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/nq> , <http://id.loc.gov/vocabulary/geographicAreas/ncnq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Nicaragua"@en , "Nicaragua"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Nicaragua> , <https://en.wikipedia.org/wiki/Nicaragua> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3041565> , <https://d-nb.info/gnd/4001937-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/an> , <http://id.loc.gov/vocabulary/geographicAreas/e-an> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Andorra"@en , "Andorra"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Andorra> , <https://de.wikipedia.org/wiki/Andorra> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4062742-1> , <http://www.geonames.org/290557> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ts> , <http://id.loc.gov/vocabulary/geographicAreas/a-ts> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Vereinigte Arabische Emirate"@de , "United Arab Emirates"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Vereinigte_Arabische_Emirate> , <https://en.wikipedia.org/wiki/United_Arab_Emirates> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4086593-9> , <http://www.geonames.org/3576396> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwaq> , <http://id.loc.gov/vocabulary/countries/aq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Antigua und Barbuda"@de , "Antigua and Barbuda"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Antigua_and_Barbuda> , <https://de.wikipedia.org/wiki/Antigua_und_Barbuda> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4030848-0> , <http://www.geonames.org/1527747> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/kg> , <http://id.loc.gov/vocabulary/geographicAreas/a-kg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kirgisien"@de , "Kyrgyzstan"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Kyrgyzstan> , <https://de.wikipedia.org/wiki/Kirgisistan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4002890-2> , <http://www.geonames.org/3865483> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-ag> , <http://id.loc.gov/vocabulary/countries/ag> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Argentina"@en , "Argentinien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Argentina> , <https://de.wikipedia.org/wiki/Argentinien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1835841> , <https://d-nb.info/gnd/4078029-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ko> , <http://id.loc.gov/vocabulary/geographicAreas/a-ko> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Südkorea"@de , "Korea (South)"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/S%C3%BCdkorea> , <https://en.wikipedia.org/wiki/South_Korea> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NW>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2861876> , <https://d-nb.info/gnd/4042570-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "North Rhine-Westphalia"@en , "Nordrhein-Westfalen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/North_Rhine-Westphalia> , <https://de.wikipedia.org/wiki/Nordrhein-Westfalen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-EH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4079248-1> , <http://www.geonames.org/2461445> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ss> , <http://id.loc.gov/vocabulary/geographicAreas/f-ss> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Westsahara"@de , "Western Sahara"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Western_Sahara> , <https://de.wikipedia.org/wiki/Westsahara> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/6290252> , <https://d-nb.info/gnd/4054598-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-rb> , <http://id.loc.gov/vocabulary/countries/rb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Serbien"@de , "Serbia"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Serbien> , <https://en.wikipedia.org/wiki/Serbia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-HT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3723988> , <https://d-nb.info/gnd/4022974-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ht> , <http://id.loc.gov/vocabulary/geographicAreas/nwht> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Haiti"@en , "Haiti"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Haiti> , <https://de.wikipedia.org/wiki/Haiti> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Australia, Oceania"@en , "Australien, Ozeanien"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XP>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "International Organizations"@en , "Internationale Staatengemeinschaften, internationale Organisationen"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2403846> , <https://d-nb.info/gnd/4054908-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-sl> , <http://id.loc.gov/vocabulary/countries/sl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sierra Leone"@en , "Sierra Leone"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Sierra_Leone> , <https://en.wikipedia.org/wiki/Sierra_Leone> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2629691> , <https://d-nb.info/gnd/4027754-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-ic> , <http://id.loc.gov/vocabulary/countries/ic> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Island"@de , "Iceland"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Island> , <https://en.wikipedia.org/wiki/Iceland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4075812-6> , <http://www.geonames.org/1168579> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-pk> , <http://id.loc.gov/vocabulary/countries/pk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Pakistan"@en , "Pakistan"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Pakistan> , <https://en.wikipedia.org/wiki/Pakistan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BW>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2953481> , <https://d-nb.info/gnd/4004176-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Baden-Württemberg"@en , "Baden-Württemberg"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg> , <https://de.wikipedia.org/wiki/Baden-W%C3%BCrttemberg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2542007> , <https://d-nb.info/gnd/4037680-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mr> , <http://id.loc.gov/vocabulary/geographicAreas/f-mr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Marokko"@de , "Morocco"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Marokko> , <https://en.wikipedia.org/wiki/Morocco> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4198311-7> , <http://www.geonames.org/3424932> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/n-xl> , <http://id.loc.gov/vocabulary/countries/xl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saint Pierre and Miquelon"@en , "Saint-Pierre-et-Miquelon"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Saint_Pierre_and_Miquelon> , <https://de.wikipedia.org/wiki/Saint-Pierre_und_Miquelon> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PCHH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/6255151> , <https://d-nb.info/gnd/4044257-3> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Oceania"@en , "Ozeanien"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Oceania> , <https://de.wikipedia.org/wiki/Ozeanien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4053881-3> , <http://www.geonames.org/2658434> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-sz> , <http://id.loc.gov/vocabulary/countries/sz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Switzerland"@en , "Schweiz"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Switzerland> , <https://de.wikipedia.org/wiki/Schweiz> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ML>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4074505-3> , <http://www.geonames.org/2453866> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-ml> , <http://id.loc.gov/vocabulary/countries/ml> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mali"@en , "Mali"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Mali> , <https://en.wikipedia.org/wiki/Mali> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-JM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3489940> , <https://d-nb.info/gnd/4028456-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwjm> , <http://id.loc.gov/vocabulary/countries/jm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Jamaika"@de , "Jamaica"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Jamaika> , <https://en.wikipedia.org/wiki/Jamaica> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4061255-7> , <http://www.geonames.org/1218197> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/tk> , <http://id.loc.gov/vocabulary/geographicAreas/a-tk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Turkmenistan"@en , "Turkmenistan"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Turkmenistan> , <https://de.wikipedia.org/wiki/Turkmenistan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2400553> , <https://d-nb.info/gnd/4019052-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-go> , <http://id.loc.gov/vocabulary/countries/go> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Gabun"@de , "Gabon"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Gabun> , <https://en.wikipedia.org/wiki/Gabon> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MV>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1282028> , <https://d-nb.info/gnd/4037212-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xc> , <http://id.loc.gov/vocabulary/geographicAreas/i-xc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Malediven"@de , "Maldives"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Malediven> , <https://en.wikipedia.org/wiki/Maldives> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/927384> , <https://d-nb.info/gnd/4074495-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mw> , <http://id.loc.gov/vocabulary/geographicAreas/f-mw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Malawi"@en , "Malawi"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Malawi> , <https://en.wikipedia.org/wiki/Malawi> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MX>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4039058-5> , <http://www.geonames.org/3996063> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mx> , <http://id.loc.gov/vocabulary/geographicAreas/n-mx> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mexico"@en , "Mexiko"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Mexico> , <https://de.wikipedia.org/wiki/Mexiko> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4061206-5> , <http://www.geonames.org/2464461> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-ti> , <http://id.loc.gov/vocabulary/countries/ti> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tunisia"@en , "Tunesien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Tunesien> , <https://en.wikipedia.org/wiki/Tunisia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-ZH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2657895> , <https://d-nb.info/gnd/4068041-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Zürich"@en , "Kanton Zürich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Z%C3%BCrich> , <https://de.wikipedia.org/wiki/Kanton_Z%C3%BCrich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4042203-3> , <http://www.geonames.org/2750405> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ne> , <http://id.loc.gov/vocabulary/geographicAreas/e-ne> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Niederlande"@de , "Netherlands"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Netherlands> , <https://de.wikipedia.org/wiki/Niederlande> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4022522-7> , <http://www.geonames.org/2372248> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-pg> , <http://id.loc.gov/vocabulary/countries/pg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guinea-Bissau"@de , "Guinea-Bissau"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Guinea-Bissau> , <https://de.wikipedia.org/wiki/Guinea-Bissau> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4085456-5> , <http://www.geonames.org/3575830> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/dq> , <http://id.loc.gov/vocabulary/geographicAreas/nwdq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Dominica"@en , "Dominica"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Dominica> , <https://en.wikipedia.org/wiki/Dominica> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SUHH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4077548-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-ur> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Soviet Union"@en , "Sowjetunion"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Soviet_Union> , <https://de.wikipedia.org/wiki/Sowjetunion> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DXDE>
+        a               skos:Concept ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Germany"@en , "Deutschland, Deutsches Reich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/German_Reich> , <https://de.wikipedia.org/wiki/Deutsches_Reich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-UZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4062199-6> , <http://www.geonames.org/1512440> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/uz> , <http://id.loc.gov/vocabulary/geographicAreas/a-uz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Uzbekistan"@en , "Usbekistan"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Usbekistan> , <https://en.wikipedia.org/wiki/Uzbekistan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3277605> , <https://d-nb.info/gnd/4088119-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bn> , <http://id.loc.gov/vocabulary/geographicAreas/e-bn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bosnien-Herzegowina"@de , "Bosnia and Hercegovina"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Bosnien_und_Herzegowina> , <https://en.wikipedia.org/wiki/Bosnia_and_Herzegovina> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CTKI>
+        a               skos:Concept ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Canton and Enderbury"@en , "Canton und Enderbury (-1984)"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3373405> , <https://d-nb.info/gnd/4003388-0> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/l> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Atlantic Ocean"@en , "Atlantischer Ozean"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Atlantic_Ocean> , <https://de.wikipedia.org/wiki/Atlantischer_Ozean> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-ID>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1643084> , <https://d-nb.info/gnd/4026761-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-io> , <http://id.loc.gov/vocabulary/countries/io> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Indonesia"@en , "Indonesien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Indonesia> , <https://de.wikipedia.org/wiki/Indonesien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3923057> , <https://d-nb.info/gnd/4007607-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bo> , <http://id.loc.gov/vocabulary/geographicAreas/s-bo> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bolivia"@en , "Bolivien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Bolivia> , <https://de.wikipedia.org/wiki/Bolivien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4077258-5> , <http://www.geonames.org/2661886> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-sw> , <http://id.loc.gov/vocabulary/countries/sw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Schweden"@de , "Sweden"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Schweden> , <https://en.wikipedia.org/wiki/Sweden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XV>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4075720-1> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Ottoman Empire"@en , "Osmanisches Reich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Ottoman_Empire> , <https://de.wikipedia.org/wiki/Osmanisches_Reich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-BV>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3371123> , <https://d-nb.info/gnd/4450775-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/lsbv> , <http://id.loc.gov/vocabulary/countries/bv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bouvetinsel"@de , "Bouvet Island"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Bouvet_Island> , <https://de.wikipedia.org/wiki/Bouvetinsel> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4005412-3> , <http://www.geonames.org/3582678> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/ncbh> , <http://id.loc.gov/vocabulary/countries/bh> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Belize"@en , "Belize"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Belize> , <https://en.wikipedia.org/wiki/Belize> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ME>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4040163-7> , <http://www.geonames.org/3194884> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-mo> , <http://id.loc.gov/vocabulary/countries/mo> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Montenegro"@en , "Montenegro"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Montenegro> , <https://de.wikipedia.org/wiki/Montenegro> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4074425-5> , <http://www.geonames.org/1062947> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-mg> , <http://id.loc.gov/vocabulary/countries/mg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Madagaskar"@de , "Madagascar"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Madagaskar> , <https://en.wikipedia.org/wiki/Madagascar> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSXX>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4692332-9> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Serbia and Montenegro"@en , "Serbien-Montenegro"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Serbia_and_Montenegro> , <https://de.wikipedia.org/wiki/Serbien-Montenegro> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-JE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3042142> , <https://d-nb.info/gnd/4028585-6> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-uk-ui> , <http://id.loc.gov/vocabulary/countries/uik> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Jersey"@en , "Jersey"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Jersey> , <https://de.wikipedia.org/wiki/Jersey> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-BQAQ>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4399981-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "British Antarctic Territory"@en , "Britisches Antarktis-Territorium"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/British_Antarctic_Territory> , <https://de.wikipedia.org/wiki/Britisches_Antarktis-Territorium> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1605651> , <https://d-nb.info/gnd/4078228-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-th> , <http://id.loc.gov/vocabulary/countries/th> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Thailand"@en , "Thailand"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Thailand> , <https://de.wikipedia.org/wiki/Thailand> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2378080> , <https://d-nb.info/gnd/4038051-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-mu> , <http://id.loc.gov/vocabulary/countries/mu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mauretanien"@de , "Mauritania"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Mauritania> , <https://de.wikipedia.org/wiki/Mauretanien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4274693-0> , <http://www.geonames.org/3578097> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwmj> , <http://id.loc.gov/vocabulary/countries/mj> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Montserrat"@en , "Montserrat (Insel)"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Montserrat> , <https://en.wikipedia.org/wiki/Montserrat> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-5>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2766823> , <https://d-nb.info/gnd/4051423-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Salzburg"@en , "Land Salzburg"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Salzburg_(state)> , <https://de.wikipedia.org/wiki/Salzburg_(Bundesland)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4236941-1> , <http://www.geonames.org/4031074> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/potl> , <http://id.loc.gov/vocabulary/countries/tl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tokelau"@en , "Tokelau"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Tokelau> , <https://de.wikipedia.org/wiki/Tokelau> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4079596-2> , <http://www.geonames.org/146669> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cy> , <http://id.loc.gov/vocabulary/geographicAreas/a-cy> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Zypern"@de , "Cyprus"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Republik_Zypern> , <https://en.wikipedia.org/wiki/Cyprus> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BS>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2661602> , <https://d-nb.info/gnd/4004617-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Basel-Stadt"@en , "Kanton Basel"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Basel-Stadt> , <https://de.wikipedia.org/wiki/Kanton_Basel-Stadt> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-LU>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2659810> , <https://d-nb.info/gnd/4036734-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Luzern"@en , "Kanton Luzern"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Lucerne> , <https://de.wikipedia.org/wiki/Kanton_Luzern> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-MV>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2872567> , <https://d-nb.info/gnd/4242861-0> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Mecklenburg-Vorpommern"@en , "Mecklenburg-Vorpommern"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Mecklenburg-Vorpommern> , <https://de.wikipedia.org/wiki/Mecklenburg-Vorpommern> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-TV>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4107331-9> , <http://www.geonames.org/2110297> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/potv> , <http://id.loc.gov/vocabulary/countries/tv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tuvalu"@en , "Tuvalu"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Tuvalu> , <https://en.wikipedia.org/wiki/Tuvalu> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2921044> , <https://d-nb.info/gnd/4011882-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-gx> , <http://id.loc.gov/vocabulary/countries/gw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Germany"@en , "Deutschland"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Deutschland> , <https://en.wikipedia.org/wiki/Germany> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AAAT>
+        a                skos:Concept ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/au> , <http://id.loc.gov/vocabulary/geographicAreas/e-au> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Austria (-12.11.1918)"@en , "Österreich (-12.11.1918)"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SKIN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4054962-8> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/countries/ii> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-sk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sikkim"@en , "Sikkim"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Sikkim> , <https://en.wikipedia.org/wiki/Sikkim> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1149361> , <https://d-nb.info/gnd/4000687-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/af> , <http://id.loc.gov/vocabulary/geographicAreas/a-af> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Afghanistan"@en , "Afghanistan"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Afghanistan> , <https://en.wikipedia.org/wiki/Afghanistan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4029400-6> , <http://www.geonames.org/1831722> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cb> , <http://id.loc.gov/vocabulary/geographicAreas/a-cb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Cambodia"@en , "Kambodscha"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kambodscha> , <https://en.wikipedia.org/wiki/Cambodia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#ZZ>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Country unknown"@en , "Land unbekannt"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/5880801> , <https://d-nb.info/gnd/4085684-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/as> , <http://id.loc.gov/vocabulary/geographicAreas/poas> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Amerikanisch-Samoa"@de , "American Samoa"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Amerikanisch-Samoa> , <https://en.wikipedia.org/wiki/American_Samoa> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HB>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2944387> , <https://d-nb.info/gnd/4008135-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Bremen"@en , "Bremen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Bremen_%28state%29> , <https://de.wikipedia.org/wiki/Freie_Hansestadt_Bremen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3202326> , <https://d-nb.info/gnd/4073841-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ci> , <http://id.loc.gov/vocabulary/geographicAreas/e-ci> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kroatien"@de , "Croatia"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kroatien> , <https://en.wikipedia.org/wiki/Croatia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GL>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2660593> , <https://d-nb.info/gnd/4021141-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Glarus"@en , "Kanton Glarus"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Glarus> , <https://de.wikipedia.org/wiki/Kanton_Glarus> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3577815> , <https://d-nb.info/gnd/4051308-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xm> , <http://id.loc.gov/vocabulary/geographicAreas/nwxm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saint Vincent and the Grenadines"@en , "Saint Vincent and the Grenadines"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/St._Vincent_und_die_Grenadinen> , <https://en.wikipedia.org/wiki/Saint_Vincent_and_the_Grenadines> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ET>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4000639-6> , <http://www.geonames.org/337996> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/et> , <http://id.loc.gov/vocabulary/geographicAreas/f-et> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Äthiopien"@de , "Ethiopia"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Ethiopia> , <https://de.wikipedia.org/wiki/%C3%84thiopien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/732800> , <https://d-nb.info/gnd/4008866-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-bu> , <http://id.loc.gov/vocabulary/countries/bu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bulgaria"@en , "Bulgarien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Bulgarien> , <https://en.wikipedia.org/wiki/Bulgaria> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/290291> , <https://d-nb.info/gnd/4004268-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ba> , <http://id.loc.gov/vocabulary/countries/ba> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bahrain"@en , "Bahrain"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Bahrain> , <https://de.wikipedia.org/wiki/Bahrain> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/433561> , <https://d-nb.info/gnd/4009181-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bd> , <http://id.loc.gov/vocabulary/geographicAreas/f-bd> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Burundi"@en , "Burundi"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Burundi> , <https://en.wikipedia.org/wiki/Burundi> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3042058> , <https://d-nb.info/gnd/4035665-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-lh> , <http://id.loc.gov/vocabulary/countries/lh> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Liechtenstein"@en , "Liechtenstein"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Liechtenstein> , <https://de.wikipedia.org/wiki/Liechtenstein> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BB>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2945356> , <https://d-nb.info/gnd/4007955-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Brandenburg"@en , "Brandenburg"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Brandenburg> , <https://de.wikipedia.org/wiki/Brandenburg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4051788-3> , <http://www.geonames.org/102358> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-su> , <http://id.loc.gov/vocabulary/countries/su> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saudi-Arabien"@de , "Saudi Arabia"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Saudi-Arabien> , <https://en.wikipedia.org/wiki/Saudi_Arabia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XQ>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "World"@en , "Gesamte Welt, Übrige Welt"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-SJ>
+        a                 skos:Concept ;
+        rdfs:seeAlso      <http://www.geonames.org/607072> , <https://d-nb.info/gnd/4509432-9> ;
+        skos:broadMatch   <http://id.loc.gov/vocabulary/geographicAreas/ln> , <http://id.loc.gov/vocabulary/countries/no> ;
+        skos:broader      <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:inScheme     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:narrowMatch  <http://id.loc.gov/vocabulary/geographicAreas/lnjn> , <http://id.loc.gov/vocabulary/geographicAreas/lnsb> ;
+        skos:prefLabel    "Svalbard und Jan Mayen"@de , "Svalbard and Jan Mayen"@en ;
+        foaf:page         <https://en.wikipedia.org/wiki/Svalbard_and_Jan_Mayen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/597427> , <https://d-nb.info/gnd/4074266-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-li> , <http://id.loc.gov/vocabulary/countries/li> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Lithuania"@en , "Litauen"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Litauen> , <https://en.wikipedia.org/wiki/Lithuania> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4055297-4> , <http://www.geonames.org/3057568> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xo> , <http://id.loc.gov/vocabulary/geographicAreas/e-xo> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Slovakia"@en , "Slowakei"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Slowakei> , <https://en.wikipedia.org/wiki/Slovakia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-FI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4017243-0> , <http://www.geonames.org/660013> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-fi> , <http://id.loc.gov/vocabulary/countries/fi> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Finland"@en , "Finnland"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Finland> , <https://de.wikipedia.org/wiki/Finnland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3175395> , <https://d-nb.info/gnd/4027833-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-it> , <http://id.loc.gov/vocabulary/countries/it> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Italy"@en , "Italien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Italy> , <https://de.wikipedia.org/wiki/Italien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4029456-0> , <http://www.geonames.org/6251999> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cn> , <http://id.loc.gov/vocabulary/geographicAreas/n-cn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Canada"@en , "Kanada"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Canada> , <https://de.wikipedia.org/wiki/Kanada> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2081918> , <https://d-nb.info/gnd/4274661-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/pomi> , <http://id.loc.gov/vocabulary/countries/fm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mikronesien (Staat)"@de , "Micronesia (Federated States)"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/F%C3%B6derierte_Staaten_von_Mikronesien> , <https://en.wikipedia.org/wiki/Federated_States_of_Micronesia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4034749> , <https://d-nb.info/gnd/4210894-9> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/p> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/wf> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Wallis and Futuna"@en , "Wallis und Futuna"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Wallis_und_Futuna> , <https://en.wikipedia.org/wiki/Wallis_and_Futuna> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BUMM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/5216525-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/br> , <http://id.loc.gov/vocabulary/geographicAreas/a-br> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Burma"@en , "Burma"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3895114> , <https://d-nb.info/gnd/4009929-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cl> , <http://id.loc.gov/vocabulary/geographicAreas/s-cl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Chile"@en , "Chile"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Chile> , <https://en.wikipedia.org/wiki/Chile> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/718075> , <https://d-nb.info/gnd/1181214262> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xn> , <http://id.loc.gov/vocabulary/geographicAreas/e-xn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Nordmazedonien"@de , "North Macedonia"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/North_Macedonia> , <https://de.wikipedia.org/wiki/Nordmazedonien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2434508> , <https://d-nb.info/gnd/4061074-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-cd> , <http://id.loc.gov/vocabulary/countries/cd> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Chad"@en , "Tschad"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Chad> , <https://de.wikipedia.org/wiki/Tschad> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4044601-3> , <http://www.geonames.org/3437598> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-py> , <http://id.loc.gov/vocabulary/countries/py> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Paraguay"@en , "Paraguay"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Paraguay> , <https://de.wikipedia.org/wiki/Paraguay> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CV>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4029617-9> , <http://www.geonames.org/3374766> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Cape Verde"@en , "Kap Verde"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Cape_Verde> , <https://de.wikipedia.org/wiki/Kap_Verde> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CX>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2078138> , <https://d-nb.info/gnd/4219436-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xa> , <http://id.loc.gov/vocabulary/geographicAreas/i-xa> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Christmas Island (Indian Ocean)"@en , "Christmas Island (Australien)"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Christmas_Island> , <https://de.wikipedia.org/wiki/Weihnachtsinsel_(Australien)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#>
+        a                              owl:Ontology , skos:ConceptScheme ;
+        rdfs:comment                   "\n\t\tChanges from 2018-10-16 to 2019-10-15\nAll d-nb.info URIs changed from http to https\nAll wikipedia.org URI changed from http to https\nXA-MK: Changed German label to \"Nordmazedonien\", English to \"North Macedonia\"\nXC-CV: Changed German label from \"Kapverdische Inseln\" to \"Kap Verde\"\nXC-KM: Changed German label from \"Komoren (Staat)\" to \"Komoren\"\nXC-ZA: Changed German label from \"Südafrika (Staat)\" to \"Südafrika\n\t\tChanges from 2018-01-16 to 2018-10-16:\nXA-AT-5: Changed German name to „Land Salzburg“, English to \"Salzburg\"\nXA-CH: The German names of all Swiss cantons now are \"Kanton ...\" English names were aligned with https://en.wikipedia.org/wiki/Cantons_of_Switzerland angepasst.\nXA-CY: Link to GND changed to https://d-nb.info/gnd/4079596-2\nXA-DDDE: Removed link to MARC Countries\nXA-YUCS: Added link to GND https://d-nb.info/gnd/4028966-7 \nXB-CN-54: skos:broader changed to https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB\nXB-ID: Wikipedia-links changed to https://de.wikipedia.org/wiki/Indonesien and https://en.wikipedia.org/wiki/Indonesia\nXB-KR: Wikipedia-links changed to https://de.wikipedia.org/wiki/S%C3%BCdkorea and https://en.wikipedia.org/wiki/South_Korea\nXB-MO: German name changed to \"Macau\", German Wikipedia-Link changed to https://de.wikipedia.org/wiki/Macau\nXB-PK: German Wikipedia-link changed to https://de.wikipedia.org/wiki/Pakistan\nXB-TW: Changed Wikipedia-Link to https://de.wikipedia.org/wiki/Republik_China_(Taiwan)\nXC-AIDJ: Added link to GND https://d-nb.info/gnd/14491-5, removed links to MARC codes\nXC-DYBJ: Changed German name to \"Dahomey\", changed GND-link to https://d-nb.info/gnd/15582-2, changed German Wikipedia-link to https://de.wikipedia.org/wiki/Republik_Dahomey, changed English Wikipedia-link to https://en.wikipedia.org/wiki/Republic_of_Dahomey geändert\nXC-RW: Changed German name to \"Ruanda\"\nXC-SS: New entry: German name \"Südsudan\", English name \"South Sudan\", Link to MARC codes http://id.loc.gov/vocabulary/geographicAreas/f-sd and http://id.loc.gov/vocabulary/countries/sd, Link zu GND https://d-nb.info/gnd/7755222-2, Links zu Wikipedia https://de.wikipedia.org/wiki/S%C3%BCdsudan and https://en.wikipedia.org/wiki/South_Sudan \nXE-CK: Changed English Wikipedia-link to https://en.wikipedia.org/wiki/Cook_Islands\nXE-NHVU: Changed German name to \"Neue Hebriden\", English name to \"New Hebrides\", changed GND-link to https://d-nb.info/gnd/61014-8, removed links zu MARC Codes, changed Wikipedia-links geändert to https://de.wikipedia.org/wiki/Kondominium_Neue_Hebriden and https://en.wikipedia.org/wiki/New_Hebrides\nXH: Added English name \"Arctic\"\nXI-FQHH: Added GND-Link https://d-nb.info/gnd/4450787-2\nXM-JTUM: Changed English name to \"Johnston Atoll\"\nXY: Changed GND-Link to https://d-nb.info/gnd/4028808-0\nZZ: Changed German name to \"Land unbekannt\", Englischer name to \"Country unknown\", removed links to Wikipedia\n\t\t"@en ;
+        cc:license                     <http://creativecommons.org/publicdomain/zero/1.0/> ;
+        dc:description                 "GND-Ländercodes ist ein RDF value vocabulary (skos:ConceptScheme), das\n\t\tdie Ländercodes, die in der Gemeinsamen Normdatei (GND) verwendet werden, aufführt."@de , "GND Geographic Area Codes is a value vocabulary (skos:ConceptScheme)\n\t\tlisting the area codes used in the Integrated Authority File (Gemeinsame Normdatei, GND)."@en ;
+        dc:title                       "GND Geographic Area Codes"@en , "GND-Ländercodes"@de ;
+        dct:available                  "2019-10-15"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dct:creator                    <file:///home/svensson/teamcity/TeamCity/buildAgent/work/661528de212fd35b/src/main/resources/rdf/standards/vocab/gnd/geographic-area-code.rdf#alexanderHaffner> ;
+        dct:issued                     "2012-06-30"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        dct:license                    <http://creativecommons.org/publicdomain/zero/1.0/> ;
+        dct:modified                   "2019-06-13T10:30:00+02:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+        dct:publisher                  <http://ld.zdb-services.de/resource/organisations/DE-101> ;
+        dct:rights                     "Copyright 2012-2019 Deutsche Nationalbibliothek" ;
+        vann:preferredNamespacePrefix  "gnd-gac" ;
+        vann:preferredNamespaceUri     "https://d-nb.info/standards/vocab/gnd/geographic-area-code#" ;
+        owl:imports                    skos: ;
+        owl:priorVersion               <http://d-nb.info/standards/vocab/gnd/geographic-area-code2018-10-16> ;
+        owl:versionIRI                 <https://d-nb.info/standards/vocab/gnd/geographic-area-code_20191015> ;
+        owl:versionInfo                "1.3" .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SG>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658821> , <https://d-nb.info/gnd/4051595-3> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "St. Gallen"@en , "Kanton Sankt Gallen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_St._Gallen> , <https://de.wikipedia.org/wiki/Kanton_St._Gallen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-TH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2822542> , <https://d-nb.info/gnd/4059979-6> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Thuringia"@en , "Thüringen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Thuringia> , <https://de.wikipedia.org/wiki/Th%C3%BCringen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2413451> , <https://d-nb.info/gnd/4019197-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-gm> , <http://id.loc.gov/vocabulary/countries/gm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Gambia"@de , "Gambia"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/The_Gambia> , <https://de.wikipedia.org/wiki/Gambia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/149590> , <https://d-nb.info/gnd/4078149-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-tz> , <http://id.loc.gov/vocabulary/countries/tz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tansania"@de , "Tanzania"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Tansania> , <https://en.wikipedia.org/wiki/Tanzania> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2155115> , <https://d-nb.info/gnd/4294928-2> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/u> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/nx> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Norfolk-Insel"@de , "Norfolk Island"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Norfolkinsel> , <https://en.wikipedia.org/wiki/Norfolk_Island> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2623032> , <https://d-nb.info/gnd/4010877-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/dk> , <http://id.loc.gov/vocabulary/geographicAreas/e-dk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Denmark"@en , "Dänemark"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/D%C3%A4nemark> , <https://en.wikipedia.org/wiki/Denmark> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4072186-3> , <http://www.geonames.org/3378535> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-gy> , <http://id.loc.gov/vocabulary/countries/gy> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guyana"@en , "Guyana"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Guyana> , <https://de.wikipedia.org/wiki/Guyana> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-YDYE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4073008-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ye> , <http://id.loc.gov/vocabulary/countries/ye> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Yemen (Republic)"@en , "Jemen (Demokratische Volksrepublik)"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Volksdemokratische_Republik_Jemen> , <https://en.wikipedia.org/wiki/Yemen,_Democratic_Republic_of> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-TI>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658370> , <https://d-nb.info/gnd/4078208-6> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Ticino"@en , "Kanton Tessin"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Ticino> , <https://de.wikipedia.org/wiki/Kanton_Tessin> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4050939-4> , <http://www.geonames.org/798549> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-rm> , <http://id.loc.gov/vocabulary/countries/rm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Rumänien"@de , "Romania"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Rum%C3%A4nien> , <https://en.wikipedia.org/wiki/Romania> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2911297> , <https://d-nb.info/gnd/4023118-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Hamburg"@en , "Hamburg"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Hamburg> , <https://de.wikipedia.org/wiki/Hamburg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/6255148> , <https://d-nb.info/gnd/4015701-5> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Europe"@en , "Europa"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Europe> , <https://de.wikipedia.org/wiki/Europa> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-GR>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2660522> , <https://d-nb.info/gnd/4021881-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Grisons"@en , "Kanton Graubünden"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Grisons> , <https://de.wikipedia.org/wiki/Kanton_Graub%C3%BCnden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1545739> , <https://d-nb.info/gnd/4026737-4> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/i> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Indian Ocean"@en , "Indischer Ozean"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Indian_Ocean> , <https://de.wikipedia.org/wiki/Indischer_Ozean> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4108287-4> , <http://www.geonames.org/4796775> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwvi> , <http://id.loc.gov/vocabulary/countries/vi> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Jungferninseln (USA)"@de , "Virgin Islands of the United States"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Amerikanische_Jungferninseln> , <https://en.wikipedia.org/wiki/United_States_Virgin_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4008479-6> , <http://www.geonames.org/1820814> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-bx> , <http://id.loc.gov/vocabulary/countries/bx> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Brunei"@en , "Brunei"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Brunei> , <https://de.wikipedia.org/wiki/Brunei> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AG>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2661876> , <https://d-nb.info/gnd/4000022-9> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Aargau"@en , "Kanton Aargau"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Aargau> , <https://de.wikipedia.org/wiki/Kanton_Aargau> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1880251> , <https://d-nb.info/gnd/4055089-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/si> , <http://id.loc.gov/vocabulary/geographicAreas/a-si> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Singapore"@en , "Singapur"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Singapur> , <https://en.wikipedia.org/wiki/Singapore> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XW>
+        a               skos:Concept ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Palestinian Arabs"@en , "Palästinenser in Geschichte und Gegenwart"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-VU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4062334-8> , <http://www.geonames.org/2134431> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/ponn> , <http://id.loc.gov/vocabulary/countries/nn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Vanuatu"@en , "Vanuatu"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Vanuatu> , <https://en.wikipedia.org/wiki/Vanuatu> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AIDJ>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/14491-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Djibouti"@en , "Französisches Afar- und Issa-Territorium"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-IO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1282588> , <https://d-nb.info/gnd/4480858-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bi> , <http://id.loc.gov/vocabulary/geographicAreas/i-bi> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Britisches Territorium im Indischen Ozean"@de , "British Indian Ocean Territory"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/British_Indian_Ocean_Territory> , <https://de.wikipedia.org/wiki/Britisches_Territorium_im_Indischen_Ozean> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AR>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2661739> , <https://d-nb.info/gnd/4002486-6> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Appenzell Ausserrhoden"@en , "Kanton Appenzell (Ausserrhoden)"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Appenzell_Ausserrhoden> , <https://de.wikipedia.org/wiki/Kanton_Appenzell_Ausserrhoden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/7755222-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sd> , <http://id.loc.gov/vocabulary/geographicAreas/f-sd> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "South Sudan"@en , "Südsudan"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/S%C3%BCdsudan> , <https://en.wikipedia.org/wiki/South_Sudan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SL>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2842635> , <https://d-nb.info/gnd/4076919-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Saarland"@en , "Saarland"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Saarland> , <https://de.wikipedia.org/wiki/Saarland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/239880> , <https://d-nb.info/gnd/4067608-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-cx> , <http://id.loc.gov/vocabulary/countries/cx> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Zentralafrikanische Republik"@de , "Central African Republic"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Central_African_Republic> , <https://de.wikipedia.org/wiki/Zentralafrikanische_Republik> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3624060> , <https://d-nb.info/gnd/4010618-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cr> , <http://id.loc.gov/vocabulary/geographicAreas/nccr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Costa Rica"@en , "Costa Rica"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Costa_Rica> , <https://en.wikipedia.org/wiki/Costa_rica> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-6>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2764581> , <https://d-nb.info/gnd/4057092-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Styria"@en , "Steiermark"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Styria> , <https://de.wikipedia.org/wiki/Steiermark> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4303381-7> , <http://www.geonames.org/3077311> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-xr> , <http://id.loc.gov/vocabulary/countries/xr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tschechische Republik"@de , "Czech Republic"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Tschechien> , <https://en.wikipedia.org/wiki/Czech_Republic> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2300660> , <https://d-nb.info/gnd/4020949-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-gh> , <http://id.loc.gov/vocabulary/countries/gh> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Ghana"@en , "Ghana"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Ghana> , <https://de.wikipedia.org/wiki/Ghana> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4022428-4> , <http://www.geonames.org/3595528> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/ncgt> , <http://id.loc.gov/vocabulary/countries/gt> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guatemala"@en , "Guatemala"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Guatemala> , <https://en.wikipedia.org/wiki/Guatemala> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4094188-7> , <http://www.geonames.org/4043988> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gu> , <http://id.loc.gov/vocabulary/geographicAreas/pogu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guam"@en , "Guam"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Guam> , <https://de.wikipedia.org/wiki/Guam> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-AI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4426211-5> , <http://www.geonames.org/3573511> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/am> , <http://id.loc.gov/vocabulary/geographicAreas/nwxa> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Anguilla"@en , "Anguilla"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Anguilla> , <https://de.wikipedia.org/wiki/Anguilla> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-AU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2077456> , <https://d-nb.info/gnd/4003900-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/at> , <http://id.loc.gov/vocabulary/geographicAreas/u-at> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Australia"@en , "Australien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Australia> , <https://de.wikipedia.org/wiki/Australien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-RU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2017370> , <https://d-nb.info/gnd/4076899-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ru> , <http://id.loc.gov/vocabulary/geographicAreas/e-ru> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Russland"@de , "Russia (Federation)"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Russland> , <https://en.wikipedia.org/wiki/Russia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-VA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3164670> , <https://d-nb.info/gnd/4062404-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/vc> , <http://id.loc.gov/vocabulary/geographicAreas/e-vc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Vatikanstadt"@de , "Vatican City"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Vatikanstadt> , <https://en.wikipedia.org/wiki/Vatican_City> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-RW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4076910-0> , <http://www.geonames.org/49518> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-rw> , <http://id.loc.gov/vocabulary/countries/rw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Rwanda"@en , "Ruanda"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Ruanda> , <https://en.wikipedia.org/wiki/Rwanda> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-RP>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2847618> , <https://d-nb.info/gnd/4049795-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Rhineland-Palatinate"@en , "Rheinland-Pfalz"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Rhineland-Palatinate> , <https://de.wikipedia.org/wiki/Rheinland-Pfalz> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-ES>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4055964-6> , <http://www.geonames.org/2510769> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-sp> , <http://id.loc.gov/vocabulary/countries/sp> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Spanien"@de , "Spain"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Spanien> , <https://en.wikipedia.org/wiki/Spain> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BJ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4005503-6> , <http://www.geonames.org/2395170> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/dm> , <http://id.loc.gov/vocabulary/geographicAreas/f-dm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Benin"@en , "Benin"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Benin> , <https://de.wikipedia.org/wiki/Benin> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4009696-8> , <http://www.geonames.org/1227603> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ce> , <http://id.loc.gov/vocabulary/geographicAreas/a-ce> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sri Lanka"@en , "Sri Lanka"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Sri_Lanka> , <https://de.wikipedia.org/wiki/Sri_Lanka> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XR>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4001451-4> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Orient"@en , "Alter Orient"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Ancient_Near_East> , <https://de.wikipedia.org/wiki/Alter_Orient> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/241170> , <https://d-nb.info/gnd/4054694-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/i-se> , <http://id.loc.gov/vocabulary/countries/se> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Seychellen"@de , "Seychelles"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Seychellen> , <https://en.wikipedia.org/wiki/Seychelles> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4006397-5> , <http://www.geonames.org/1252634> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-bt> , <http://id.loc.gov/vocabulary/countries/bt> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bhutan"@en , "Bhutan"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Bhutan> , <https://de.wikipedia.org/wiki/Bhutan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4036728-9> , <http://www.geonames.org/2960313> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/lu> , <http://id.loc.gov/vocabulary/geographicAreas/e-lu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Luxembourg"@en , "Luxemburg"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Luxemburg> , <https://en.wikipedia.org/wiki/Luxembourg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2245662> , <https://d-nb.info/gnd/4054529-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sg> , <http://id.loc.gov/vocabulary/geographicAreas/f-sg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Senegal"@en , "Senegal"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Senegal> , <https://de.wikipedia.org/wiki/Senegal> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BY>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2951839> , <https://d-nb.info/gnd/4005044-0> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Bavaria"@en , "Bayern"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Bavaria> , <https://de.wikipedia.org/wiki/Bayern> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-PL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/798544> , <https://d-nb.info/gnd/4046496-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/pl> , <http://id.loc.gov/vocabulary/geographicAreas/e-pl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Polen"@de , "Poland"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Polen> , <https://en.wikipedia.org/wiki/Poland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-CC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4298716-7> , <http://www.geonames.org/1547376> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xb> , <http://id.loc.gov/vocabulary/geographicAreas/i-xb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kokosinseln"@de , "Cocos (Keeling) Islands"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kokosinseln> , <https://en.wikipedia.org/wiki/Cocos_(Keeling)_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1327865> , <https://d-nb.info/gnd/4069500-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/br> , <http://id.loc.gov/vocabulary/geographicAreas/a-br> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Birma"@de , "Burma"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Myanmar> , <https://en.wikipedia.org/wiki/Burma> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-1>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2781194> , <https://d-nb.info/gnd/4009114-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Burgenland"@en , "Burgenland"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Burgenland> , <https://de.wikipedia.org/wiki/Burgenland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-MP>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4041468> , <https://d-nb.info/gnd/4249308-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/nw> , <http://id.loc.gov/vocabulary/geographicAreas/poxd> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Northern Mariana Islands"@en , "Nördliche Marianen"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Northern_Mariana_Islands> , <https://de.wikipedia.org/wiki/N%C3%B6rdliche_Marianen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI-FQHH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4450787-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Terres australes et antarctiques françaises"@en , "Terres Australes et Antarctiques Françaises"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Terres_australes_et_antarctiques_fran%C3%A7aises> , <https://de.wikipedia.org/wiki/Franz%C3%B6sische_S%C3%BCd-_und_Antarktisgebiete> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZRCD>
+        a               skos:Concept ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Congo (Democratic Republic)"@en , "Kongo (Demokratische Republik)(Zaire)"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-WKUM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4041685> , <https://d-nb.info/gnd/4401852-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/powk> , <http://id.loc.gov/vocabulary/countries/wk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Wake Island"@en , "Wake Island"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Wake_island> , <https://de.wikipedia.org/wiki/Wake-Insel> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4021981-1> , <http://www.geonames.org/3580239> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gd> , <http://id.loc.gov/vocabulary/geographicAreas/nwgd> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Grenada"@en , "Grenada"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Grenada> , <https://de.wikipedia.org/wiki/Grenada> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658760> , <https://d-nb.info/gnd/4051995-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Schaffhausen"@en , "Kanton Schaffhausen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Schaffhausen> , <https://de.wikipedia.org/wiki/Kanton_Schaffhausen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VS>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658205> , <https://d-nb.info/gnd/4064466-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Valais"@en , "Kanton Wallis"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Valais> , <https://de.wikipedia.org/wiki/Kanton_Wallis> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-GN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4022520-3> , <http://www.geonames.org/2420477> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gv> , <http://id.loc.gov/vocabulary/geographicAreas/f-gv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guinea"@en , "Guinea"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Guinea> , <https://en.wikipedia.org/wiki/Guinea> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2440476> , <https://d-nb.info/gnd/4042298-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ng> , <http://id.loc.gov/vocabulary/geographicAreas/f-ng> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Niger"@en , "Niger"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Niger> , <https://de.wikipedia.org/wiki/Niger> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PUUM>
+        a               skos:Concept ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "American Territory in the Pacific (-1986)"@en , "Amerikanisches Territorium im Pazifik (-1986)"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-HVBF>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4088707-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Burkina Faso"@en , "Burkina Faso (Obervolta)"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-DO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3508796> , <https://d-nb.info/gnd/4012694-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/dr> , <http://id.loc.gov/vocabulary/geographicAreas/nwdr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Dominican Republic"@en , "Dominikanische Republik"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Dominikanische_Republik> , <https://en.wikipedia.org/wiki/Dominican_Republic> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-KE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/192950> , <https://d-nb.info/gnd/4030236-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-ke> , <http://id.loc.gov/vocabulary/countries/ke> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kenya"@en , "Kenia"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kenia> , <https://en.wikipedia.org/wiki/Kenya> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-UG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/226074> , <https://d-nb.info/gnd/4061457-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-ug> , <http://id.loc.gov/vocabulary/countries/ug> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Uganda"@en , "Uganda"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Uganda> , <https://en.wikipedia.org/wiki/Uganda> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2110425> , <https://d-nb.info/gnd/4122008-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/ponu> , <http://id.loc.gov/vocabulary/countries/nu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Nauru"@en , "Nauru"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Nauru> , <https://de.wikipedia.org/wiki/Nauru> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-NI>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2862926> , <https://d-nb.info/gnd/4042226-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Lower Saxony"@en , "Niedersachsen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Lower_Saxony> , <https://de.wikipedia.org/wiki/Niedersachsen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4001028-4> , <http://www.geonames.org/783754> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/aa> , <http://id.loc.gov/vocabulary/geographicAreas/e-aa> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Albanien"@de , "Albania"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Albania> , <https://de.wikipedia.org/wiki/Albanien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-AM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/174982> , <https://d-nb.info/gnd/4085931-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ai> , <http://id.loc.gov/vocabulary/countries/ai> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Armenien"@de , "Armenia (Republic)"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Armenia> , <https://de.wikipedia.org/wiki/Armenien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL-RE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/935317> , <https://d-nb.info/gnd/4049639-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XL> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/re> , <http://id.loc.gov/vocabulary/geographicAreas/i-re> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Réunion"@en , "Réunion"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/R%C3%A9union> , <https://de.wikipedia.org/wiki/R%C3%A9union> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-US>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/6252001> , <https://d-nb.info/gnd/4078704-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xxu> , <http://id.loc.gov/vocabulary/geographicAreas/n-us> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "United States"@en , "USA"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Vereinigte_Staaten> , <https://en.wikipedia.org/wiki/United_States> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1522867> , <https://d-nb.info/gnd/4029839-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/kz> , <http://id.loc.gov/vocabulary/geographicAreas/a-kz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kasachstan"@de , "Kazakhstan"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kasachstan> , <https://en.wikipedia.org/wiki/Kazakhstan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/6255147> , <https://d-nb.info/gnd/4003217-6> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Asia"@en , "Asien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Asia> , <https://de.wikipedia.org/wiki/Asien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-BD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4130903-0> , <http://www.geonames.org/1210997> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-bg> , <http://id.loc.gov/vocabulary/countries/bg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bangladesh"@en , "Bangladesch"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Bangladesch> , <https://en.wikipedia.org/wiki/Bangladesh> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VDVN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4078050-8> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-vt> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/vs> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Südvietnam"@de , "Vietnam (South)"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/S%C3%BCdvietnam> , <https://en.wikipedia.org/wiki/South_vietnam> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2363254> , <https://d-nb.info/gnd/4044981-6> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/p> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Pacific Ocean"@en , "Pazifischer Ozean"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Pacific_Ocean> , <https://de.wikipedia.org/wiki/Pazifischer_Ozean> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-YT>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4115054-5> , <http://www.geonames.org/1024031> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/i-my> , <http://id.loc.gov/vocabulary/countries/ot> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mayotte"@en , "Mayotte"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Mayotte> , <https://de.wikipedia.org/wiki/Mayotte> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2963597> , <https://d-nb.info/gnd/4027667-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ie> , <http://id.loc.gov/vocabulary/geographicAreas/e-ie> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Irland"@de , "Ireland"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Ireland> , <https://de.wikipedia.org/wiki/Irland_(Insel)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4035583-4> , <http://www.geonames.org/2275384> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/lb> , <http://id.loc.gov/vocabulary/geographicAreas/f-lb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Liberia"@en , "Liberia"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Liberia> , <https://de.wikipedia.org/wiki/Liberia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XX>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4068789-2> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Arab Countries"@en , "Arabische Staaten, Araber"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Arab_world> , <https://de.wikipedia.org/wiki/Arabische_Staaten> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-BY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4079143-9> , <http://www.geonames.org/630336> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-bw> , <http://id.loc.gov/vocabulary/countries/bw> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Belarus"@en , "Weißrussland"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Belarus> , <https://de.wikipedia.org/wiki/Wei%C3%9Frussland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IQ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4072920-5> , <http://www.geonames.org/99237> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-iq> , <http://id.loc.gov/vocabulary/countries/iq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Iraq"@en , "Irak"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Iraq> , <https://de.wikipedia.org/wiki/Irak> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-PH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1694008> , <https://d-nb.info/gnd/4045771-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ph> , <http://id.loc.gov/vocabulary/countries/ph> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Philippinen"@de , "Philippines"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Philippines> , <https://de.wikipedia.org/wiki/Philippinen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ST>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4118426-9> , <http://www.geonames.org/2410758> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-sf> , <http://id.loc.gov/vocabulary/countries/sf> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sao Tomé und Príncipe"@de , "Sao Tome and Principe"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/S%C3%A3o_Tom%C3%A9_and_Pr%C3%ADncipe> , <https://de.wikipedia.org/wiki/S%C3%A3o_Tom%C3%A9_und_Pr%C3%ADncipe> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4016258-8> , <http://www.geonames.org/2622320> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/fa> , <http://id.loc.gov/vocabulary/geographicAreas/lnfa> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Färöer"@de , "Faroe Islands"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Faroe_Island> , <https://de.wikipedia.org/wiki/F%C3%A4r%C3%B6er> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4032097-2> , <http://www.geonames.org/2260494> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-cf> , <http://id.loc.gov/vocabulary/countries/cf> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kongo (Republik)"@de , "Congo (Brazzaville)"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Republik_Kongo> , <https://en.wikipedia.org/wiki/Republic_of_the_Congo> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-OW>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2659315> , <https://d-nb.info/gnd/4078653-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Obwalden"@en , "Kanton Obwalden"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Obwalden> , <https://de.wikipedia.org/wiki/Kanton_Obwalden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN-54>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4060036-1> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/countries/cc> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-cc-ti> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tibet (China)"@en , "Tibet"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Tibet> , <https://en.wikipedia.org/wiki/Tibet> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TJ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1220409> , <https://d-nb.info/gnd/4058877-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ta> , <http://id.loc.gov/vocabulary/countries/ta> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Tadschikistan"@de , "Tajikistan"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Tajikistan> , <https://de.wikipedia.org/wiki/Tadschikistan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-7>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2763586> , <https://d-nb.info/gnd/4060207-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Tyrol"@en , "Tirol"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Tyrol_(state)> , <https://de.wikipedia.org/wiki/Tirol_(Bundesland)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3042362> , <https://d-nb.info/gnd/4022467-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-uk-ui> , <http://id.loc.gov/vocabulary/countries/uik> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guernsey"@en , "Guernsey"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Guernsey> , <https://en.wikipedia.org/wiki/Guernsey> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4022047-3> , <http://www.geonames.org/390903> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gr> , <http://id.loc.gov/vocabulary/geographicAreas/e-gr> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Greece"@en , "Griechenland"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Griechenland> , <https://en.wikipedia.org/wiki/Greece> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-ANHH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4101202-1> , <http://www.geonames.org/8505032> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwsd> , <http://id.loc.gov/vocabulary/countries/na> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Niederländische Antillen"@de , "Netherlands Antilles"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Netherlands_Antilles> , <https://de.wikipedia.org/wiki/Niederl%C3%A4ndische_Antillen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-NU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4036232> , <https://d-nb.info/gnd/4293521-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xh> , <http://id.loc.gov/vocabulary/geographicAreas/poxh> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Niue"@en , "Niue"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Niue> , <https://en.wikipedia.org/wiki/Niue> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-UY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3439705> , <https://d-nb.info/gnd/4062186-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-uy> , <http://id.loc.gov/vocabulary/countries/uy> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Uruguay"@de , "Uruguay"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Uruguay> , <https://de.wikipedia.org/wiki/Uruguay> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4034571-3> , <http://www.geonames.org/1655842> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ls> , <http://id.loc.gov/vocabulary/geographicAreas/a-ls> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Laos"@en , "Laos"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Laos> , <https://de.wikipedia.org/wiki/Laos> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2960860> , <https://d-nb.info/gnd/4002924-4> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/r> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Arctic"@en , "Arktis"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Arctic> , <https://de.wikipedia.org/wiki/Arktis> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-LC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3576468> , <https://d-nb.info/gnd/4051307-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xk> , <http://id.loc.gov/vocabulary/geographicAreas/nwxk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saint Lucia"@en , "Saint Lucia"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/St._Lucia> , <https://en.wikipedia.org/wiki/Saint_Lucia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-NE>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2659495> , <https://d-nb.info/gnd/4041745-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Neuchâtel"@en , "Kanton Neuenburg"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Neuch%C3%A2tel> , <https://de.wikipedia.org/wiki/Kanton_Neuenburg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-VE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3625428> , <https://d-nb.info/gnd/4062512-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-ve> , <http://id.loc.gov/vocabulary/countries/ve> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Venezuela"@en , "Venezuela"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Venezuela> , <https://de.wikipedia.org/wiki/Venezuela> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3578476> , <https://d-nb.info/gnd/4271726-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwsc> , <http://id.loc.gov/vocabulary/countries/sc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saint Barthélemy"@en , "Saint-Barthélemy (Kleine Antillen)"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Saint_Barth%C3%A9lemy> , <https://de.wikipedia.org/wiki/Saint-Barth%C3%A9lemy_(Insel)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XS>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4093976-5> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Greece"@en , "Griechenland (Altertum)"@de ;
+        foaf:page       <https://de.wikipedia.org/wiki/Antikes_Griechenland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-VN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1562822> , <https://d-nb.info/gnd/4063514-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-vt> , <http://id.loc.gov/vocabulary/countries/vm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Vietnam"@en , "Vietnam"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Vietnam> , <https://de.wikipedia.org/wiki/Vietnam> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SD>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4058378-8> , <http://www.geonames.org/366755> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sj> , <http://id.loc.gov/vocabulary/geographicAreas/f-sj> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Sudan"@en , "Sudan"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Sudan> , <https://de.wikipedia.org/wiki/Sudan> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/294640> , <https://d-nb.info/gnd/4027808-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-is> , <http://id.loc.gov/vocabulary/countries/is> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Israel"@en , "Israel"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Israel> , <https://de.wikipedia.org/wiki/Israel> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-LV>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4074187-4> , <http://www.geonames.org/458258> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-lv> , <http://id.loc.gov/vocabulary/countries/lv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Latvia"@en , "Lettland"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Latvia> , <https://de.wikipedia.org/wiki/Lettland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-UR>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658226> , <https://d-nb.info/gnd/4062129-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Uri"@en , "Kanton Uri"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Uri> , <https://de.wikipedia.org/wiki/Kanton_Uri> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-SM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3168068> , <https://d-nb.info/gnd/4051524-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sm> , <http://id.loc.gov/vocabulary/geographicAreas/e-sm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "San Marino"@en , "San Marino"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/San_Marino> , <https://de.wikipedia.org/wiki/San_Marino> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-PE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4045312-1> , <http://www.geonames.org/3932488> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-pe> , <http://id.loc.gov/vocabulary/countries/pe> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Peru"@en , "Peru"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Peru> , <https://de.wikipedia.org/wiki/Peru> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4077509-4> , <http://www.geonames.org/51537> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/so> , <http://id.loc.gov/vocabulary/geographicAreas/f-so> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Somalia"@en , "Somalia"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Somalia> , <https://de.wikipedia.org/wiki/Somalia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4030656> , <https://d-nb.info/gnd/4018191-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/pofp> , <http://id.loc.gov/vocabulary/countries/fp> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "French Polynesia"@en , "Französisch-Polynesien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Franz%C3%B6sisch-Polynesien> , <https://en.wikipedia.org/wiki/French_Polynesia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2838632> , <https://d-nb.info/gnd/4052692-6> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Schleswig-Holstein"@en , "Schleswig-Holstein"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Schleswig-Holstein> , <https://de.wikipedia.org/wiki/Schleswig-Holstein> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-GEHH>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4345823-3> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Gilbert Islands"@en , "Gilbertinseln"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Gilbert_Islands> , <https://de.wikipedia.org/wiki/Gilbertinseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-PN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4030699> , <https://d-nb.info/gnd/4115982-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/popc> , <http://id.loc.gov/vocabulary/countries/pc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Pitcairn"@de , "Pitcairn Island"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Pitcairninseln> , <https://en.wikipedia.org/wiki/Pitcairn_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-SY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/163843> , <https://d-nb.info/gnd/4058794-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sy> , <http://id.loc.gov/vocabulary/geographicAreas/a-sy> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Syria"@en , "Syrien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Syrien> , <https://en.wikipedia.org/wiki/Syria> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-SZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/934841> , <https://d-nb.info/gnd/4058692-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-sq> , <http://id.loc.gov/vocabulary/countries/sq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Swaziland"@en , "Swasiland"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Swaziland> , <https://de.wikipedia.org/wiki/Swasiland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DDDE>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4011890-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-ge> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Germany East"@en , "Deutschland (DDR)"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/East_Germany> , <https://de.wikipedia.org/wiki/DDR> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-CM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4029413-4> , <http://www.geonames.org/2233387> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/cm> , <http://id.loc.gov/vocabulary/geographicAreas/f-cm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Cameroon"@en , "Kamerun"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kamerun> , <https://en.wikipedia.org/wiki/Cameroon> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-BE>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2661551> , <https://d-nb.info/gnd/4005765-3> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Bern"@en , "Kanton Bern"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Bern> , <https://de.wikipedia.org/wiki/Kanton_Bern> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MN>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2029969> , <https://d-nb.info/gnd/4040056-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mp> , <http://id.loc.gov/vocabulary/geographicAreas/a-mp> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mongolei"@de , "Mongolia"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Mongolei> , <https://en.wikipedia.org/wiki/Mongolia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-2>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2774686> , <https://d-nb.info/gnd/4029175-3> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Carinthia"@en , "Kärnten"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Carinthia_%28state%29> , <https://de.wikipedia.org/wiki/K%C3%A4rnten> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CSHH>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4078435-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/xr> , <http://id.loc.gov/vocabulary/geographicAreas/e-cs> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Czechoslovakia"@en , "Tschechoslowakei"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Tschechoslowakei> , <https://en.wikipedia.org/wiki/Czechoslovakia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-WS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/4034894> , <https://d-nb.info/gnd/4079249-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ws> , <http://id.loc.gov/vocabulary/geographicAreas/pows> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Samoa"@en , "Westsamoa"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Samoa> , <https://en.wikipedia.org/wiki/Samoa> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-GB>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2635167> , <https://d-nb.info/gnd/4022153-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-uk> , <http://id.loc.gov/vocabulary/countries/xxk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Großbritannien"@de , "Great Britain"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Vereinigtes_K%C3%B6nigreich> , <https://en.wikipedia.org/wiki/United_Kingdom> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4037203-0> , <http://www.geonames.org/1733045> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-my> , <http://id.loc.gov/vocabulary/countries/my> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Malaysia"@en , "Malaysia"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Malaysia> , <https://de.wikipedia.org/wiki/Malaysia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1036973> , <https://d-nb.info/gnd/4039786-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mz> , <http://id.loc.gov/vocabulary/geographicAreas/f-mz> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mozambique"@en , "Moçambique"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Mozambique> , <https://de.wikipedia.org/wiki/Mosambik> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-GL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3425505> , <https://d-nb.info/gnd/4022113-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/gl> , <http://id.loc.gov/vocabulary/geographicAreas/n-gl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Grönland"@de , "Greenland"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Greenland> , <https://de.wikipedia.org/wiki/Gr%C3%B6nland> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GP>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3579143> , <https://d-nb.info/gnd/4086841-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwgp> , <http://id.loc.gov/vocabulary/countries/gp> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Guadeloupe"@de , "Guadeloupe"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Guadeloupe> , <https://de.wikipedia.org/wiki/Guadeloupe> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-NO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3144096> , <https://d-nb.info/gnd/4042640-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/no> , <http://id.loc.gov/vocabulary/geographicAreas/e-no> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Norway"@en , "Norwegen"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Norwegen> , <https://en.wikipedia.org/wiki/Norway> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-FR>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2660717> , <https://d-nb.info/gnd/4018279-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Fribourg"@en , "Kanton Freiburg (Üechtland)"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Fribourg> , <https://de.wikipedia.org/wiki/Kanton_Freiburg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-NP>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4041612-4> , <http://www.geonames.org/1282988> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/np> , <http://id.loc.gov/vocabulary/geographicAreas/a-np> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Nepal"@en , "Nepal"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Nepal> , <https://en.wikipedia.org/wiki/Nepal> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT-32>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/3165244> , <https://d-nb.info/gnd/4060814-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-IT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Trentino-Alto Adige Italy"@en , "Trentino-Südtirol"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Trentino-Alto_Adige/S%C3%BCdtirol> , <https://de.wikipedia.org/wiki/Trentino-S%C3%BCdtirol> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DYBJ>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/15582-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Dahomey"@en , "Dahomey"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Republic_of_Dahomey> , <https://de.wikipedia.org/wiki/Republik_Dahomey> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-AO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3351879> , <https://d-nb.info/gnd/4002050-2> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ao> , <http://id.loc.gov/vocabulary/geographicAreas/f-ao> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Angola"@de , "Angola"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Angola> , <https://en.wikipedia.org/wiki/Angola> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DZ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2589581> , <https://d-nb.info/gnd/4001179-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ae> , <http://id.loc.gov/vocabulary/geographicAreas/f-ae> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Algeria"@en , "Algerien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Algerien> , <https://en.wikipedia.org/wiki/Algeria> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-KP>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1873107> , <https://d-nb.info/gnd/4075468-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-kn> , <http://id.loc.gov/vocabulary/countries/kn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Korea (North)"@en , "Nordkorea"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Nordkorea> , <https://en.wikipedia.org/wiki/North_Korea> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AX>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/661882> , <https://d-nb.info/gnd/4001012-0> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/countries/fi> , <http://id.loc.gov/vocabulary/geographicAreas/e-fi> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Ǻland Island"@en , "Ålandinseln"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/%C3%85land_Islands> , <https://de.wikipedia.org/wiki/%C3%85land> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/6255146> , <https://d-nb.info/gnd/4000695-5> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Africa"@en , "Afrika"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Africa> , <https://de.wikipedia.org/wiki/Afrika> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2361809> , <https://d-nb.info/gnd/4088707-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-uv> , <http://id.loc.gov/vocabulary/countries/uv> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Burkina Faso"@en , "Burkina Faso"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Burkina_Faso> , <https://de.wikipedia.org/wiki/Burkina_Faso> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XN>
+        a                skos:Concept ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/zo> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Outer Space"@en , "Extraterrestrika"@de .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3469034> , <https://d-nb.info/gnd/4008003-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bl> , <http://id.loc.gov/vocabulary/geographicAreas/s-bl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Brazil"@en , "Brasilien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Brazil> , <https://de.wikipedia.org/wiki/Brasilien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-AI>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2661741> , <https://d-nb.info/gnd/4002489-1> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Appenzell Innerrhoden"@en , "Kanton Appenzell (Innerrhoden)"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Appenzell_Innerrhoden> , <https://de.wikipedia.org/wiki/Kanton_Appenzell_Innerrhoden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4074183-7> , <http://www.geonames.org/932692> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/lo> , <http://id.loc.gov/vocabulary/geographicAreas/f-lo> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Lesotho"@en , "Lesotho"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Lesotho> , <https://en.wikipedia.org/wiki/Lesotho> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XY>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4028808-0> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Jews"@en , "Juden"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Jews> , <https://de.wikipedia.org/wiki/Juden> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/953987> , <https://d-nb.info/gnd/4078012-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-sa> , <http://id.loc.gov/vocabulary/countries/sa> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Südafrika"@de , "South Africa"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/South_Africa> , <https://de.wikipedia.org/wiki/S%C3%BCdafrika> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-IR>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/130758> , <https://d-nb.info/gnd/4027653-3> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-ir> , <http://id.loc.gov/vocabulary/countries/ir> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Iran"@en , "Iran"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Iran> , <https://en.wikipedia.org/wiki/Iran> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-FJ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4017063-9> , <http://www.geonames.org/2205218> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/fj> , <http://id.loc.gov/vocabulary/geographicAreas/pofj> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Fidschi"@de , "Fiji"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Fidschi> , <https://en.wikipedia.org/wiki/Fiji> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-SV>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4014499-9> , <http://www.geonames.org/3585968> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/es> , <http://id.loc.gov/vocabulary/geographicAreas/nces> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "El Salvador"@en , "El Salvador"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/El_Salvador> , <https://en.wikipedia.org/wiki/El_Salvador> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-SN>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2842566> , <https://d-nb.info/gnd/4051176-5> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Saxony"@en , "Sachsen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Saxony> , <https://de.wikipedia.org/wiki/Sachsen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-YUCS>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4028966-7> , <https://d-nb.info/gnd/4339067-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-yu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Föderative Republik Jugoslawien; Jugoslawien"@de , "Yugoslavia"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Yugoslavia> , <https://de.wikipedia.org/wiki/Jugoslawien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-VD>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658182> , <https://d-nb.info/gnd/4078982-2> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Vaud"@en , "Kanton Waadt"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Vaud> , <https://de.wikipedia.org/wiki/Kanton_Waadt> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4044396-6> , <http://www.geonames.org/1559582> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/pw> , <http://id.loc.gov/vocabulary/geographicAreas/popl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Palauinseln"@de , "Palau"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Palau> , <https://en.wikipedia.org/wiki/Palau> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-ZW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4049850-5> , <http://www.geonames.org/878675> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/rh> , <http://id.loc.gov/vocabulary/geographicAreas/f-rh> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Simbabwe"@de , "Zimbabwe"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Simbabwe> , <https://en.wikipedia.org/wiki/Zimbabwe> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-MU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/934292> , <https://d-nb.info/gnd/4074641-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mf> , <http://id.loc.gov/vocabulary/geographicAreas/i-mf> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Mauritius"@en , "Mauritius"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Mauritius> , <https://en.wikipedia.org/wiki/Mauritius> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-8>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2762300> , <https://d-nb.info/gnd/4063944-7> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Vorarlberg"@en , "Vorarlberg"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Vorarlberg> , <https://de.wikipedia.org/wiki/Vorarlberg> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-NA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3355338> , <https://d-nb.info/gnd/4075202-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/sx> , <http://id.loc.gov/vocabulary/geographicAreas/f-sx> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Namibia"@en , "Namibia"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Namibia> , <https://en.wikipedia.org/wiki/Namibia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-NC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2139685> , <https://d-nb.info/gnd/4102498-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/ponl> , <http://id.loc.gov/vocabulary/countries/nl> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "New Caledonia"@en , "Neukaledonien"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Neukaledonien> , <https://en.wikipedia.org/wiki/New_Caledonia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SO>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658563> , <https://d-nb.info/gnd/4055459-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Solothurn"@en , "Kanton Solothurn"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Solothurn> , <https://de.wikipedia.org/wiki/Kanton_Solothurn> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-DJ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4070610-2> , <http://www.geonames.org/223816> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-ft> , <http://id.loc.gov/vocabulary/countries/ft> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Dschibuti"@de , "Djibouti"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Djibouti> , <https://de.wikipedia.org/wiki/Dschibuti> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-JTUM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/5854928> , <https://d-nb.info/gnd/4464500-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ji> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Johnston Atoll"@en , "Johnston-Inseln (-1986)"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Johnston_Island> , <https://de.wikipedia.org/wiki/Johnston-Inseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-UA>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/690791> , <https://d-nb.info/gnd/4061496-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/un> , <http://id.loc.gov/vocabulary/geographicAreas/e-un> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Ukraine"@en , "Ukraine"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Ukraine> , <https://en.wikipedia.org/wiki/Ukraine> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH-SZ>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2658664> , <https://d-nb.info/gnd/4054019-4> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Schwyz"@en , "Kanton Schwyz"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Canton_of_Schwyz> , <https://de.wikipedia.org/wiki/Kanton_Schwyz> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM-UM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/5854968> , <https://d-nb.info/gnd/4451497-9> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XM> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/poup> , <http://id.loc.gov/vocabulary/countries/up> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Amerikanische Überseeinseln"@de , "United States Misc. Pacific Islands"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/United_States_Minor_Outlying_Islands> , <https://en.wikipedia.org/wiki/United_States_Minor_Outlying_Islands> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-HK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4025822-1> , <http://www.geonames.org/1819730> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/countries/hk> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-cc-hk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Hong Kong"@en , "Hongkong"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Hongkong> , <https://en.wikipedia.org/wiki/Hk> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-HE>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2905330> , <https://d-nb.info/gnd/4024729-6> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Hesse"@en , "Hessen"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Hesse> , <https://de.wikipedia.org/wiki/Hessen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-HU>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/719819> , <https://d-nb.info/gnd/4078541-5> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/e-hu> , <http://id.loc.gov/vocabulary/countries/hu> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Hungary"@en , "Ungarn"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Ungarn> , <https://en.wikipedia.org/wiki/Hungary> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BB>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4004487-7> , <http://www.geonames.org/3374084> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwbb> , <http://id.loc.gov/vocabulary/countries/bb> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Barbados"@en , "Barbados"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Barbados> , <https://de.wikipedia.org/wiki/Barbados> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-LB>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/272103> , <https://d-nb.info/gnd/4035567-6> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-le> , <http://id.loc.gov/vocabulary/countries/le> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Lebanon"@en , "Libanon"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Lebanon> , <https://de.wikipedia.org/wiki/Libanon> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-OM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4075653-1> , <http://www.geonames.org/286963> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-mk> , <http://id.loc.gov/vocabulary/countries/mk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Oman"@en , "Oman"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Oman> , <https://de.wikipedia.org/wiki/Oman> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XI>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4002208-0> , <http://www.geonames.org/6255152> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ay> , <http://id.loc.gov/vocabulary/geographicAreas/t> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Antarktis"@de , "Antarctic Ocean/Antarctica"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Antarktis> , <https://en.wikipedia.org/wiki/Antarctic> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-BM>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3573345> , <https://d-nb.info/gnd/4005759-8> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/bm> , <http://id.loc.gov/vocabulary/geographicAreas/lnbm> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Bermudainseln"@de , "Bermuda Islands"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Bermuda> , <https://en.wikipedia.org/wiki/Bermuda> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-BE>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2950157> , <https://d-nb.info/gnd/4005728-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Berlin"@en , "Berlin"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Berlin> , <https://de.wikipedia.org/wiki/Berlin> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XT>
+        a               skos:Concept ;
+        rdfs:seeAlso    <https://d-nb.info/gnd/4076778-4> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Rome"@en , "Römisches Reich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Roman_Empire> , <https://de.wikipedia.org/wiki/R%C3%B6misches_Reich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-BW>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/933860> , <https://d-nb.info/gnd/4007857-7> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-bs> , <http://id.loc.gov/vocabulary/countries/bs> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Botswana"@en , "Botswana"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Botsuana> , <https://en.wikipedia.org/wiki/Botswana> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-LY>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4035589-5> , <http://www.geonames.org/2215636> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ly> , <http://id.loc.gov/vocabulary/geographicAreas/f-ly> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Libya"@en , "Libyen"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Libya> , <https://de.wikipedia.org/wiki/Libyen> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE-PG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2088628> , <https://d-nb.info/gnd/4044569-0> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XE> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-pp> , <http://id.loc.gov/vocabulary/countries/pp> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Papua New Guinea"@en , "Papua-Neuguinea"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Papua-Neuguinea> , <https://en.wikipedia.org/wiki/Papua_New_Guinea> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK-FK>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4071109-2> , <http://www.geonames.org/3474414> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/geographicAreas/lsxs> , <http://id.loc.gov/vocabulary/geographicAreas/t> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XK> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/fk> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Falkland Islands"@en , "Falklandinseln"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Falkland_Islands> , <https://de.wikipedia.org/wiki/Falklandinseln> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#GeographicAreaCodeValue>
+        a                    owl:Class ;
+        rdfs:comment         "Die möglichen Instanzen dieser Klasse sind beschränkt auf diejenigen\n            skos:Concepts, die zum Concept Scheme <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> gehören."@de , "The possible members of this class is restricted to those skos:Concepts\n            that are in the Concept Scheme <https://d-nb.info/standards/vocab/gnd/geographic-area-code#>."@en ;
+        rdfs:label           "Werte für GND-Ländercodes"@de , "Geographic Area Code Value"@en ;
+        rdfs:subClassOf      skos:Concept ;
+        owl:equivalentClass  [ a               owl:Restriction ;
+                               owl:hasValue    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+                               owl:onProperty  skos:inScheme
+                             ] .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-MC>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/2993457> , <https://d-nb.info/gnd/4040031-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mc> , <http://id.loc.gov/vocabulary/geographicAreas/e-mc> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Monaco"@en , "Monaco"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Monaco> , <https://en.wikipedia.org/wiki/Monaco> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4435868-4> , <http://www.geonames.org/3578421> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/nwsn> , <http://id.loc.gov/vocabulary/countries/sn> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Saint-Martin (Kleine Antillen, Nord)"@de , "Saint Martin, Northern"@en ;
+        foaf:page        <https://en.wikipedia.org/wiki/Saint_Martin_(France)> , <https://de.wikipedia.org/wiki/Saint-Martin_(Gebietsk%C3%B6rperschaft)> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE-ST>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2842565> , <https://d-nb.info/gnd/4051181-9> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Saxony-Anhalt"@en , "Sachsen-Anhalt"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Saxony-Anhalt> , <https://de.wikipedia.org/wiki/Sachsen-Anhalt> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-CO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4031812-6> , <http://www.geonames.org/3686110> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/ck> , <http://id.loc.gov/vocabulary/geographicAreas/s-ck> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Kolumbien"@de , "Colombia"@en ;
+        foaf:page        <https://de.wikipedia.org/wiki/Kolumbien> , <https://en.wikipedia.org/wiki/Colombia> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-MO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/1821275> , <https://d-nb.info/gnd/4036791-5> ;
+        skos:broadMatch  <http://id.loc.gov/vocabulary/countries/cc> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/a-cc-mh> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Macau (China : Special Administrative Region)"@en , "Macau"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Macau> , <https://de.wikipedia.org/wiki/Macau> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-MQ>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4037735-0> , <http://www.geonames.org/3570311> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/mq> , <http://id.loc.gov/vocabulary/geographicAreas/nwmq> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Martinique"@en , "Martinique"@de ;
+        foaf:page        <https://de.wikipedia.org/wiki/Martinique> , <https://en.wikipedia.org/wiki/Martinique> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT-3>
+        a               skos:Concept ;
+        rdfs:seeAlso    <http://www.geonames.org/2770542> , <https://d-nb.info/gnd/4075391-8> ;
+        skos:broader    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-AT> ;
+        skos:inScheme   <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel  "Lower Austria"@en , "Niederösterreich"@de ;
+        foaf:page       <https://en.wikipedia.org/wiki/Lower_Austria> , <https://de.wikipedia.org/wiki/Nieder%C3%B6sterreich> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC-TG>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4060344-1> , <http://www.geonames.org/2363686> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XC> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/f-tg> , <http://id.loc.gov/vocabulary/countries/tg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Togo"@en , "Togo"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Togo> , <https://de.wikipedia.org/wiki/Togo> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-JO>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4028750-6> , <http://www.geonames.org/248816> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/jo> , <http://id.loc.gov/vocabulary/geographicAreas/a-jo> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "Jordan"@en , "Jordanien"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/Jordan> , <https://de.wikipedia.org/wiki/Jordanien> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-GF>
+        a                skos:Concept ;
+        rdfs:seeAlso     <http://www.geonames.org/3381670> , <https://d-nb.info/gnd/4018184-4> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/geographicAreas/s-fg> , <http://id.loc.gov/vocabulary/countries/fg> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "French Guiana"@en , "Französisch-Guayana"@de ;
+        foaf:page        <https://en.wikipedia.org/wiki/French_Guiana> , <https://de.wikipedia.org/wiki/Franz%C3%B6sisch-Guayana> .
+
+<https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-TPTL>
+        a                skos:Concept ;
+        rdfs:seeAlso     <https://d-nb.info/gnd/4075765-1> ;
+        skos:broader     <https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB> ;
+        skos:exactMatch  <http://id.loc.gov/vocabulary/countries/em> , <http://id.loc.gov/vocabulary/geographicAreas/a-em> ;
+        skos:inScheme    <https://d-nb.info/standards/vocab/gnd/geographic-area-code#> ;
+        skos:prefLabel   "East Timor"@en , "Osttimor"@de .


### PR DESCRIPTION
Will finally resolve #256. 

I started by adding the current country code file from https://d-nb.info/standards/vocab/gnd/geographic-area-code_20191015.ttl and creating a tab-separated URI-to-label map with the added Pythoin script.

The map is no to be used in lobid-gnd. Also, @fsteeg, let me know if the map should look different.