### PR TITLE
Use only direct children, not nested (e.g. `broader`) labels (#256)

### DIFF
--- a/app/models/GndOntology.java
+++ b/app/models/GndOntology.java
@@ -179,7 +179,7 @@ public class GndOntology {
 			String classId = c.getAttribute("rdf:about");
 			if (classId.contains("#")) {
 				String shortId = classId.split("#")[1];
-				String label = $(c).find(or(//
+				String label = $(c).children(or( //
 						selector("label"), //
 						selector("prefLabel"))).filter(attr("lang", "de")).content();
 				if (label != null) {

--- a/test/models/GndOntologyLabelTests.java
+++ b/test/models/GndOntologyLabelTests.java
@@ -25,6 +25,8 @@ public class GndOntologyLabelTests {
 				{ "gndIdentifier", "GND-Nummer" }, //
 				{ "ZZ", "Land unbekannt" }, //
 				{ "https://d-nb.info/standards/vocab/gnd/gnd-sc#ZZ", "Land unbekannt" }, //
+				{ "XA-CH", "Schweiz" }, //
+				{ "https://d-nb.info/standards/vocab/gnd/gnd-sc#XA-CH", "Schweiz" }, //
 				{ "36", "Basteln, Handarbeiten, Heimwerken" }, //
 				{ "https://d-nb.info/standards/vocab/gnd/geographic-area-code#36", "Basteln, Handarbeiten, Heimwerken" }, //
 				{ "notKnown", "Unbekannt" }, //


### PR DESCRIPTION
Will resolve #256.

Deployed to test for a single entry (via update for its `dateModified`): http://test.lobid.org/gnd/1085901955

After production deployment updates will start getting the correct label, old entries with next baseline.