### PR TITLE
Support `label_fieldName` auto-complete templates, e.g. `*_dateOfBirth` (RPB-169)

### DIFF
--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -411,7 +411,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 			Optional<JsonNode> type = getOptional(document, "type");
 			Stream<String> labels = Arrays.asList(fields.split(",")).stream().map(String::trim)
 					.map(field -> AuthorityResource.fieldValues(field, document)
-							.collect(Collectors.joining(", ")));
+							.collect(Collectors.joining(AuthorityResource.VALUE_DELIMITER)));
 			List<String> categories = filtered(Lists.newArrayList(type.orElseGet(() -> Json.toJson("[]")).elements())
 					.stream().map(JsonNode::asText).filter(t -> !t.equals("AuthorityResource"))
 					.collect(Collectors.toList()));

--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -417,7 +417,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 					.collect(Collectors.toList()));
 			return toSuggestionsMap(document, id, labels, categories);
 		});
-		return Json.toJson(suggestions.distinct().collect(Collectors.toList())).toString();
+		return Json.prettyPrint(Json.toJson(suggestions.distinct().collect(Collectors.toList())));
 	}
 
 	@SuppressWarnings("serial")

--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -348,7 +348,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 			}
 		} catch (Throwable t) {
 			String message = t.getMessage() + (t.getCause() != null ? ", cause: " + t.getCause().getMessage() : "");
-			Logger.error("Error: {}", message);
+			Logger.error("Error: " + message, t);
 			return internalServerError(views.html.error.render(q, "Error: " + message));
 		}
 	}
@@ -406,17 +406,16 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 				"placeOfBusiness", "firstAuthor", "firstComposer", "dateOfProduction");
 		String fields = labelFields.equals("suggest") ? defaultFields.collect(Collectors.joining(",")) : labelFields;
 		Stream<JsonNode> documents = Lists.newArrayList(json.elements()).stream();
-		Stream<JsonNode> suggestions = documents.map((JsonNode document) -> {
+		Stream<Map<String, Object>> suggestions = documents.map((JsonNode document) -> {
 			Optional<JsonNode> id = getOptional(document, "id");
 			Optional<JsonNode> type = getOptional(document, "type");
 			Stream<String> labels = Arrays.asList(fields.split(",")).stream().map(String::trim)
-					.map(field -> AuthorityResource.fieldValues(field, document).map((JsonNode node) -> //
-			(node.isTextual() ? Optional.ofNullable(node) : Optional.ofNullable(node.findValue("label")))
-					.orElseGet(() -> Json.toJson("")).asText()).collect(Collectors.joining(", ")));
+					.map(field -> AuthorityResource.fieldValues(field, document)
+							.collect(Collectors.joining(", ")));
 			List<String> categories = filtered(Lists.newArrayList(type.orElseGet(() -> Json.toJson("[]")).elements())
 					.stream().map(JsonNode::asText).filter(t -> !t.equals("AuthorityResource"))
 					.collect(Collectors.toList()));
-			return Json.toJson(toSuggestionsMap(document, id, labels, categories));
+			return toSuggestionsMap(document, id, labels, categories);
 		});
 		return Json.toJson(suggestions.distinct().collect(Collectors.toList())).toString();
 	}

--- a/app/models/AuthorityResource.java
+++ b/app/models/AuthorityResource.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.Scanner;
 import java.util.TreeSet;
 import java.util.function.IntFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -93,7 +95,7 @@ public class AuthorityResource {
 	}
 
 	public String subTitle() {
-		String lifeDates = fieldValues("dateOfBirth-dateOfDeath", json).map(JsonNode::asText)
+		String lifeDates = fieldValues("dateOfBirth-dateOfDeath", json)
 				.collect(Collectors.joining());
 		String details = find("definition", "biographicalOrHistoricalInformation");
 		return Stream.of(lifeDates, details).filter(s -> !s.isEmpty()).collect(Collectors.joining(" | "));
@@ -449,24 +451,63 @@ public class AuthorityResource {
 		return result;
 	}
 
-	public static Stream<JsonNode> fieldValues(String field, JsonNode document) {
-		if (field.contains("-")) {
-			String[] fields = field.split("-");
-			String v1 = year(document.findValue(fields[0]));
-			String v2 = year(document.findValue(fields[1]));
-			return v1.isEmpty() && v2.isEmpty() ? Stream.empty()
-					: Stream.of(Json.toJson(String.format("%s-%s", v1, v2)));
+	public static Stream<String> fieldValues(String field, JsonNode document) {
+		// standard case: `field` is a plain field name, use that:
+		List<String> result = flatStrings(document.findValues(field));
+		if (result.isEmpty()) {
+			// `label_fieldName` template, e.g. `*_dateOfBirth`
+			if (field.contains("_")) {
+				Matcher matcher = Pattern.compile("([^_]+)_([A-Za-z]+)").matcher(field);
+				while (matcher.find()) {
+					String label = matcher.group(1);
+					String fieldName = matcher.group(2);
+					List<JsonNode> findValues = document.findValues(fieldName);
+					if (!findValues.isEmpty()) {
+						String values = flatStrings(findValues).stream()
+								.collect(Collectors.joining());
+						field = field.replace(matcher.group(), label + " " + values);
+					} else {
+						field = field.replace(matcher.group(), "");
+					}
+				}
+				result = field.trim().isEmpty() ? Arrays.asList() : Arrays.asList(field);
+			}
+			// date ranges, e.g. `dateOfBirth-dateOfDeath`
+			else if (field.contains("-")) {
+				String[] fields = field.split("-");
+				String v1 = year(document.findValue(fields[0]));
+				String v2 = year(document.findValue(fields[1]));
+				result = v1.isEmpty() && v2.isEmpty() ? Lists.newArrayList()
+						: Arrays.asList(String.format("%s-%s", v1, v2));
+			}
 		}
-		return document.findValues(field).stream().flatMap((node) -> {
-			return node.isArray() ? Lists.newArrayList(node.elements()).stream() : Arrays.asList(node).stream();
-		});
+		return result.stream();
+	}
+
+	private static List<String> flatStrings(List<JsonNode> values) {
+		return values.stream().flatMap(node -> toArray(node)).map(node -> toString(node))
+				.collect(Collectors.toList());
+	}
+
+	private static Stream<JsonNode> toArray(JsonNode node) {
+		return node.isArray() ? Lists.newArrayList(node.elements()).stream()
+				: Arrays.asList(node).stream();
+	}
+
+	private static String toString(JsonNode node) {
+		return year((node.isTextual() ? Optional.ofNullable(node)
+				: Optional.ofNullable(node.findValue("label"))).orElseGet(() -> Json.toJson(""))
+						.asText());
 	}
 
 	private static String year(JsonNode node) {
 		if (node == null || !node.isArray() || node.size() == 0) {
 			return "";
 		}
-		String text = node.elements().next().asText();
+		return year(node.elements().next().asText());
+	}
+
+	private static String year(String text) {
 		return text.matches("\\d{4}-\\d{2}-\\d{2}") ? text.split("-")[0] : text;
 	}
 }

--- a/app/models/AuthorityResource.java
+++ b/app/models/AuthorityResource.java
@@ -36,6 +36,7 @@ public class AuthorityResource {
 	public static final String DNB_PREFIX = "https://d-nb.info/";
 	public static final String GND_PREFIX = DNB_PREFIX + "gnd/";
 	public static final String ELEMENTSET = DNB_PREFIX + "standards/elementset/";
+	public static final String VALUE_DELIMITER = "; ";
 	private static final List<String> SKIP = Arrays.asList(//
 			// handled explicitly:
 			"@context", "id", "type", "depiction", "sameAs", "preferredName", "hasGeometry", "definition",
@@ -464,7 +465,7 @@ public class AuthorityResource {
 					List<JsonNode> findValues = document.findValues(fieldName);
 					if (!findValues.isEmpty()) {
 						String values = flatStrings(findValues).stream()
-								.collect(Collectors.joining("; "));
+								.collect(Collectors.joining(VALUE_DELIMITER));
 						field = field.replace(matcher.group(), label + " " + values);
 					} else {
 						field = field.replace(matcher.group(), "");

--- a/app/models/AuthorityResource.java
+++ b/app/models/AuthorityResource.java
@@ -464,7 +464,7 @@ public class AuthorityResource {
 					List<JsonNode> findValues = document.findValues(fieldName);
 					if (!findValues.isEmpty()) {
 						String values = flatStrings(findValues).stream()
-								.collect(Collectors.joining());
+								.collect(Collectors.joining("; "));
 						field = field.replace(matcher.group(), label + " " + values);
 					} else {
 						field = field.replace(matcher.group(), "");

--- a/app/views/api.scala.html
+++ b/app/views/api.scala.html
@@ -78,6 +78,7 @@ $('input.search-gnd').autocomplete({
   @desc("Standardformat für Vorschläge verwenden: \"format=json:suggest\"", routes.HomeController.search("Twain", format="json:suggest"))
   @desc("Bestimmtes Feld für Vorschläge verwenden: \"format=json:preferredName\"", routes.HomeController.search("Twain", format="json:preferredName"))
   @desc("Vorschläge aus mehreren Feldern zusammenbauen: \"format=json:preferredName,professionOrOccupation\"", routes.HomeController.search("Twain", format="json:preferredName,professionOrOccupation"))
+  @desc("Feld-Templates zur Anpassung und Gruppierung: \"format=json:preferredName,*_dateOfBirth in_placeOfBirth,†_dateOfDeath in_placeOfDeath\"", routes.HomeController.search("Twain", format="json:preferredName,*_dateOfBirth in_placeOfBirth,†_dateOfDeath in_placeOfDeath"))
   <p>Damit kann z.B. eine Autovervollständigung umgesetzt werden, bei der zur Suche an Stelle des gewählten Labels die entsprechende ID verwendet werden kann:</p>
   <p><form method="GET" class="form-inline" action="@routes.HomeController.search()">
     <input type="text" class="search-gnd" id="label" style="width:350px" placeholder="Suchbegriff für Vorschläge eingeben"/>

--- a/test/controllers/SuggestionsTest.java
+++ b/test/controllers/SuggestionsTest.java
@@ -69,4 +69,21 @@ public class SuggestionsTest extends IndexTest {
 
 	}
 
+	@Test
+	public void suggestionsTemplate() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			String format = "json:preferredName,*_dateOfBirth+in_placeOfBirth";
+			Result result = route(application,
+					fakeRequest(GET, "/gnd/search?q=*&filter=type:Person&format=" + format));
+			assertNotNull("We have a result", result);
+			assertThat(result.contentType().get(), is(equalTo("application/json")));
+			String content = contentAsString(result);
+			assertNotNull("We can parse the result as JSON", Json.parse(content));
+			assertTrue("We replaced the field names in the template with their values",
+					Json.parse(content).findValues("label").stream()
+							.anyMatch(label -> label.asText()
+									.contains("* 1923 in https://d-nb.info/gnd/4005728-8")));
+		});
+	}
 }

--- a/test/controllers/SuggestionsTest.java
+++ b/test/controllers/SuggestionsTest.java
@@ -91,17 +91,17 @@ public class SuggestionsTest extends IndexTest {
 	public void suggestionsTemplateMultiValues() {
 		Application application = fakeApplication();
 		running(application, () -> {
-			String format = "json:preferredName,aka_variantName";
+			String format = "json:preferredName,gndSubjectCategory,aka_variantName";
 			Result result = route(application,
-					fakeRequest(GET, "/gnd/search?q=*&filter=type:Person&format=" + format));
+					fakeRequest(GET, "/gnd/search?q=Weizenbaum&filter=type:Person&format=" + format));
 			assertNotNull("We have a result", result);
 			assertThat(result.contentType().get(), is(equalTo("application/json")));
 			String content = contentAsString(result);
 			assertNotNull("We can parse the result as JSON", Json.parse(content));
-			assertTrue("We replaced the field name in the template with multiple delimited values",
-					Json.parse(content).findValues("label").stream()
-							.anyMatch(label -> label.asText()
-									.contains("aka Weizenbaum, Josef; Weizenbaum, J.")));
+			assertThat("Multi-values use consistent delimiter", content,
+					allOf(
+						containsString("Personen zu Informatik, Datenverarbeitung; Personen zu Mathematik"),
+						containsString("aka Weizenbaum, Josef; Weizenbaum, J.")));
 		});
 	}
 

--- a/test/controllers/SuggestionsTest.java
+++ b/test/controllers/SuggestionsTest.java
@@ -104,4 +104,17 @@ public class SuggestionsTest extends IndexTest {
 									.contains("aka Weizenbaum, Josef; Weizenbaum, J.")));
 		});
 	}
+
+	@Test
+	public void suggestionsArePrettyPrinted() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			Result result = route(application,
+					fakeRequest(GET, "/gnd/search?q=*&format=json:suggest"));
+			assertNotNull(result);
+			assertThat(result.contentType().get(), is(equalTo("application/json")));
+			assertThat(contentAsString(result), containsString("}, {\n"));
+		});
+	}
+
 }

--- a/test/controllers/SuggestionsTest.java
+++ b/test/controllers/SuggestionsTest.java
@@ -86,4 +86,22 @@ public class SuggestionsTest extends IndexTest {
 									.contains("* 1923 in https://d-nb.info/gnd/4005728-8")));
 		});
 	}
+
+	@Test
+	public void suggestionsTemplateMultiValues() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			String format = "json:preferredName,aka_variantName";
+			Result result = route(application,
+					fakeRequest(GET, "/gnd/search?q=*&filter=type:Person&format=" + format));
+			assertNotNull("We have a result", result);
+			assertThat(result.contentType().get(), is(equalTo("application/json")));
+			String content = contentAsString(result);
+			assertNotNull("We can parse the result as JSON", Json.parse(content));
+			assertTrue("We replaced the field name in the template with multiple delimited values",
+					Json.parse(content).findValues("label").stream()
+							.anyMatch(label -> label.asText()
+									.contains("aka Weizenbaum, Josef; Weizenbaum, J.")));
+		});
+	}
 }


### PR DESCRIPTION
E.g. [preferredName,*_dateOfBirth in_placeOfBirth,†_dateOfDeath in_placeOfDeath](https://test.lobid.org/gnd/search?q=Twain&format=json%3ApreferredName%2C*_dateOfBirth+in_placeOfBirth%2C%E2%80%A0_dateOfDeath+in_placeOfDeath)

New sample at https://test.lobid.org/gnd/api#auto-complete

See https://jira.hbz-nrw.de/browse/RPB-169