### PR TITLE
Add `description-level` vocab, add full IDs for lookups (#359)

### DIFF
--- a/app/models/GndOntology.java
+++ b/app/models/GndOntology.java
@@ -67,6 +67,7 @@ public class GndOntology {
 		try {
 			process("conf/geographic-area-code.rdf");
 			process("conf/gender.rdf");
+			process("conf/description-level.rdf");
 			process("conf/gnd-sc.rdf");
 			process("conf/gnd.rdf");
 			process("conf/agrelon.rdf");
@@ -149,8 +150,10 @@ public class GndOntology {
 	}
 
 	private static String ontologyLabel(String id) {
-		String key = id.contains("#") ? id.split("#")[1] : id;
-		String result = labels.get(key);
+		String result = labels.get(id);
+		if (result == null && id.contains("#")) {
+			result = labels.get(id.split("#")[1]);
+		}
 		return result == null ? id : result;
 	}
 
@@ -183,7 +186,9 @@ public class GndOntology {
 						selector("label"), //
 						selector("prefLabel"))).filter(attr("lang", "de")).content();
 				if (label != null) {
-					labels.put(shortId, label.replaceAll("\\s+", " ").replace("hat ", ""));
+					String value = label.replaceAll("\\s+", " ").replace("hat ", "");
+					labels.put(shortId, value);
+					labels.put(classId, value);
 				}
 			}
 		});

--- a/conf/description-level.rdf
+++ b/conf/description-level.rdf
@@ -1,0 +1,98 @@
+<rdf:RDF
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:adms="http://www.w3.org/ns/adms#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:vann="http://purl.org/vocab/vann/">
+  <owl:Class rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#DescriptionLevelValue">
+    <owl:equivalentClass>
+      <owl:Restriction>
+        <owl:hasValue>
+          <skos:ConceptScheme rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#">
+            <owl:versionIRI rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level_20220903"/>
+            <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+            <adms:versionNotes xml:lang="en">
+2022-09-03
+
+New Value Vocabulary
+		</adms:versionNotes>
+            <dc:description xml:lang="de">GND-Katalogisierungslevel ist ein RDF value vocabulary (skos:ConceptScheme),
+		das die möglichen Werte auflistet, die Angaben zum Katalogisierungslevel in der RDF-Ausgabe der Gemeinsamen
+		Normdatei (GND) haben können. Mehr Informationen dazu unter https://wiki.dnb.de/download/attachments/50759357/005.pdf</dc:description>
+            <dc:title xml:lang="de">GND-Katalogisierungslevel</dc:title>
+            <dct:available rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+            >2022-09-03</dct:available>
+            <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+            <dct:rights>Copyright 2022 Deutsche Nationalbibliothek</dct:rights>
+            <vann:preferredNamespaceUri>https://d-nb.info/standards/vocab/gnd/description-level#</vann:preferredNamespaceUri>
+            <dc:description xml:lang="en">GND Description Level is a value vocabulary (skos:ConceptScheme) listing 
+		the possible description level values used in the RDF encoding of the information in the Integrated
+		Authority File (Gemeinsame Normdatei, GND). More information on this scale at https://wiki.dnb.de/download/attachments/50759357/005.pdf (in german)</dc:description>
+            <dct:publisher rdf:resource="http://ld.zdb-services.de/resource/organisations/DE-101"/>
+            <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime"
+            >2022-09-03T10:30:00+02:00</dct:modified>
+            <vann:preferredNamespacePrefix>gnd-dl</vann:preferredNamespacePrefix>
+            <dc:title xml:lang="en">GND Description Level</dc:title>
+            <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core#"/>
+            <owl:versionInfo>1.0</owl:versionInfo>
+            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+            >2022-09-03</dct:issued>
+            <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+          </skos:ConceptScheme>
+        </owl:hasValue>
+        <owl:onProperty rdf:resource="http://www.w3.org/2004/02/skos/core#inScheme"/>
+      </owl:Restriction>
+    </owl:equivalentClass>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="de">Die möglichen Instanzen dieser Klasse sind beschränkt auf diejenigen
+            skos:Concepts, die zum Concept Scheme &lt;https://d-nb.info/standards/vocab/gnd/description-level#&gt; gehören.</rdfs:comment>
+    <rdfs:comment xml:lang="en">The possible members of this class is restricted to those skos:Concepts
+            that are in the Concept Scheme &lt;https://d-nb.info/standards/vocab/gnd/description-level#&gt;.</rdfs:comment>
+    <rdfs:label xml:lang="de">Katalogisierungslevel</rdfs:label>
+    <rdfs:label xml:lang="en">Description Level</rdfs:label>
+  </owl:Class>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#7">
+    <skos:prefLabel xml:lang="en">Description Level 7</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 7</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#z">
+    <skos:prefLabel xml:lang="en">Description Level z</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel z</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#3">
+    <skos:prefLabel xml:lang="en">Description Level 3</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 3</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#4">
+    <skos:prefLabel xml:lang="en">Description Level 4</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 4</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#5">
+    <skos:prefLabel xml:lang="en">Description Level 5</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 5</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#6">
+    <skos:prefLabel xml:lang="en">Description Level 6</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 6</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#1">
+    <skos:prefLabel xml:lang="en">Description Level 1</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 1</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="https://d-nb.info/standards/vocab/gnd/description-level#2">
+    <skos:prefLabel xml:lang="en">Description Level 2</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Katalogisierungslevel 2</skos:prefLabel>
+    <skos:inScheme rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#"/>
+  </skos:Concept>
+</rdf:RDF>

--- a/test/models/GndOntologyLabelTests.java
+++ b/test/models/GndOntologyLabelTests.java
@@ -39,6 +39,7 @@ public class GndOntologyLabelTests {
 				{ "broadMatch", "Oberbegriff" }, //
 				{ "exactMatch", "Entspricht" }, //
 				{ "relatedMatch", "Verwandter Begriff" }, //
+				{ "https://d-nb.info/standards/vocab/gnd/description-level#3", "Katalogisierungslevel 3" }, //
 				{ "SubjectHeadingSensoStricto", "Schlagwort sensu stricto" } });
 	}
 


### PR DESCRIPTION
Will resolve #359.

Applies to new transformations. Deployed to test, re-ran updates for 2024-06-05:

https://test.lobid.org/gnd/search?q=describedBy.dateModified:2024-06-05&format=json