### PR TITLE
Set up reconciliation service for subdomain usage

### DIFF
--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -467,8 +467,8 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 		List<Map<String, Object>> hits = Arrays.asList(queryResponse.getHits().getHits()).stream()
 				.map(hit -> hit.getSource()).collect(Collectors.toList());
 		ObjectNode object = Json.newObject();
-		object.put("@context", config("host") + routes.HomeController.context());
-		object.put("id", config("host") + request().uri());
+		object.put("@context", configNested("host", "main") + routes.HomeController.context());
+		object.put("id", configNested("host", "main") + request().uri());
 		object.put("totalItems", queryResponse.getHits().getTotalHits());
 		object.set("member", Json.toJson(hits));
 

--- a/app/controllers/HomeController.java
+++ b/app/controllers/HomeController.java
@@ -117,7 +117,7 @@ public class HomeController extends Controller implements WSBodyReadables, WSBod
 	 * @return A 301 MOVED_PERMANENTLY redirect to the path
 	 */
 	public Result redirectSlash(String path) {
-		return movedPermanently("/" + path);
+		return movedPermanently("/" + path).withHeader("Access-Control-Allow-Origin", "*");
 	}
 
 	public Result index() {

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -104,7 +104,7 @@ public class Reconcile extends Controller {
 	}
 
 	private ObjectNode metadata() {
-		final String host = HomeController.config("host");
+		final String host = HomeController.configNested("host", "reconcile");
 		ObjectNode result = Json.newObject();
 		result.putArray("versions").add("0.1").add("0.2");
 		result.put("name", "GND reconciliation for OpenRefine");
@@ -151,7 +151,7 @@ public class Reconcile extends Controller {
 
 	private ObjectNode suggestService(String suggest) {
 		return Json.newObject()//
-				.put("service_url", HomeController.config("host") + "/gnd/reconcile")//
+				.put("service_url", HomeController.configNested("host", "reconcile"))//
 				.put("service_path", "/suggest/" + suggest)//
 				.put("flyout_service_path", "/flyout/" + suggest + "?id=${id}");
 	}

--- a/app/views/gnd.scala.html
+++ b/app/views/gnd.scala.html
@@ -61,8 +61,9 @@
             <div class="panel panel-default footer-gnd">
               <div class="panel-body">
                 <span class="pull-left">
-                    <img id='small-logo' src='@controllers.routes.Assets.versioned("images/gnd.png")' alt="GND-Logo"/> &nbsp;
-                    GND Reconciliation | ein Dienst im <a href='https://gnd.network'>gnd.network</a>
+                    <a href='https://gnd.network'><img id='small-logo' src='@controllers.routes.Assets.versioned("images/gnd.png")' alt="GND-Logo"/></a>
+                    <a href='https://www.hbz-nrw.de'><img id='small-logo' src='@controllers.routes.Assets.versioned("images/hbz.png")' alt="hbz-Logo"/></a> &nbsp;
+                    GND Reconciliation | ein <a href='https://lobid.org'>lobid</a>-Dienst im <a href='https://gnd.network'>gnd.network</a>
                 </span>
                 <span class="pull-right">
 	                <a href="http://lobid.org/warranty">Gewährleistung</a> | 

--- a/app/views/gnd.scala.html
+++ b/app/views/gnd.scala.html
@@ -33,10 +33,10 @@
                         <span class="icon-bar"></span>
                     </button>
                     <a class="navbar-brand" href="https://lobid.org/gnd">
-                     <img id="small-logo" src='../assets/images/favicon.png' alt="lobid-gnd"/>
+                     <img id="small-logo" src='@controllers.routes.Assets.versioned("images/favicon.png")' alt="lobid-gnd"/>
                     </a>
                     <a class="navbar-brand" id="small-gnd-logo-link" href="https://gnd.network">
-                     <img id="small-logo" src='../assets/images/gnd.png' alt="gnd.network"/>
+                     <img id="small-logo" src='@controllers.routes.Assets.versioned("images/gnd.png")' alt="gnd.network"/>
                     </a>
                   </div>
                   <div class="navbar-collapse collapse" id="resources-nav">

--- a/app/views/gnd.scala.html
+++ b/app/views/gnd.scala.html
@@ -33,10 +33,10 @@
                         <span class="icon-bar"></span>
                     </button>
                     <a class="navbar-brand" href="https://lobid.org/gnd">
-                     <img id="small-logo" src='@controllers.routes.Assets.versioned("images/favicon.png")' alt="lobid-gnd"/>
+                     <img id="small-logo" src='../assets/images/favicon.png' alt="lobid-gnd"/>
                     </a>
                     <a class="navbar-brand" id="small-gnd-logo-link" href="https://gnd.network">
-                     <img id="small-logo" src='@controllers.routes.Assets.versioned("images/gnd.png")' alt="gnd.network"/>
+                     <img id="small-logo" src='../assets/images/gnd.png' alt="gnd.network"/>
                     </a>
                   </div>
                   <div class="navbar-collapse collapse" id="resources-nav">

--- a/app/views/preview.scala.html
+++ b/app/views/preview.scala.html
@@ -3,7 +3,7 @@
 @(resource: String)
 
 @import play.api.libs.json._
-@import controllers.HomeController.CONFIG
+@import controllers.HomeController.configNested
 
 <html><head><meta charset="utf-8" /></head>
 <body style="margin: 0px; font-family: Arial; sans-serif">
@@ -16,7 +16,7 @@
 		details = elems.tail.mkString(" | ");
 		fullId <- (json \ "id").asOpt[String];
 		shortId = fullId.split("/").last;
-		url = CONFIG.getString("host") + routes.HomeController.authority(shortId,null);
+		url = configNested("host", "reconcile") + routes.HomeController.authority(shortId,null);
 		cat <- (json \ "category").asOpt[String];
 		image = (json \ "image").asOpt[String]) {
 	@for(img <- image){

--- a/app/views/reconcile.scala.html
+++ b/app/views/reconcile.scala.html
@@ -20,7 +20,7 @@
 
   <p>Dieser Dienst ermöglicht den Abgleich eigener Daten mit der Gemeinsamen Normdatei, insbesondere mit OpenRefine, einem nicht nur im Bibliotheksbereich weitverbreiteten Werkzeug. OpenRefine bietet zahlreiche Funktionalitäten zur Bereinigung und Transformation von Daten, sowie zum Abgleich (Reconciliation) mit externen Datenquellen und zur Anreicherung auf Basis der abgeglichenen Daten. Dieser Dienst stellt die GND als eine solche Datenquelle in OpenRefine bereit. Der Dienst kann zugleich auch in anderen Anwendungen verwendet werden, z. B. im Bibliotheksmanagementsystem Alma über Alma Refine (s. <a href="https://reconciliation-api.github.io/census/clients/">weitere Clients</a>).</p>
 
-  <p>Service-URL: <code>@controllers.HomeController.config("host")</code></p>
+  <p>Service-URL: <code>@controllers.HomeController.configNested("host", "reconcile")</code></p>
 
   <h2>Daten und Werkzeuge</h2>
 
@@ -50,11 +50,11 @@
   <h3>Allgemeine API <small>(<a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410">spec</a>)</small></h3>
 
   <p><b>Service</b><br/>
-  <code>curl @controllers.HomeController.config("host")</code>
+  <code>curl @controllers.HomeController.configNested("host", "reconcile")</code>
   <p><b>JSONP-callback</b><br/>
-  <code>curl @controllers.HomeController.config("host")?callback=jsonp</code>
+  <code>curl @controllers.HomeController.configNested("host", "reconcile")?callback=jsonp</code>
   <p><b>CORS-header</b><br/>
-  <code>curl --head @controllers.HomeController.config("host") | grep Access-Control-Allow-Origin</code>
+  <code>curl --head @controllers.HomeController.configNested("host", "reconcile") | grep Access-Control-Allow-Origin</code>
   </p>
 
   <h3>View-API</h3>
@@ -66,7 +66,7 @@
 
   @desc("Query: GET", routes.Reconcile.main(queries="{\"q1\":{\"query\":\"Twain, Mark\"}}"))
   <p><b>Query: POST</b><br/>
-  <code>curl --data 'queries={"q1":{"query":"Twain, Mark"}}' @controllers.HomeController.config("host")</code></p>
+  <code>curl --data 'queries={"q1":{"query":"Twain, Mark"}}' @controllers.HomeController.configNested("host", "reconcile")</code></p>
 
   <h3>Suggest-API <small>(<a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#suggest-services">spec</a>)</small></h3>
 
@@ -82,6 +82,6 @@
   @desc("Property-proposals (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-property-proposals\">spec</a>)", routes.Reconcile.properties("","Work",""))
   @desc("Extend: GET (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-service\">spec</a>)", routes.Reconcile.main(extend="{\"ids\":[\"1081942517\",\"4791358-7\"],\"properties\":[{\"id\":\"preferredName\"},{\"id\":\"firstAuthor\"}]}"))
   <p><b>Extend: POST</b><br/>
-  <code>curl --data 'extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}' @controllers.HomeController.config("host")</code></p>
+  <code>curl --data 'extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}' @controllers.HomeController.configNested("host", "reconcile")</code></p>
 
 }

--- a/app/views/reconcile.scala.html
+++ b/app/views/reconcile.scala.html
@@ -2,8 +2,10 @@
 
 @()
 
-@desc(label: String, link: play.api.mvc.Call) = {
+@desc(label: String, call: play.api.mvc.Call) = {
+ @defining(call.toString.replace("/gnd/reconcile/", "")) { link =>
  <dt>@Html(label)</dt> <dd><a href='@link'>@java.net.URLDecoder.decode(link.toString.replaceAll("[&?]format=json$", ""), "UTF-8")</a></dd>
+ }
 }
 
 @gnd("GND Reconciliation") {
@@ -62,8 +64,7 @@
 
   <h3>Query-API <small>(<a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#reconciliation-queries">spec</a>)</small></h3>
 
-  <p><b>Query: GET</b><br/>
-  <a href='@controllers.HomeController.config("host")/?queries={"q1":{"query":"Twain, Mark"}}'>/?queries={"q1":{"query":"Twain, Mark"}}</a>
+  @desc("Query: GET", routes.Reconcile.main(queries="{\"q1\":{\"query\":\"Twain, Mark\"}}"))
   <p><b>Query: POST</b><br/>
   <code>curl --data 'queries={"q1":{"query":"Twain, Mark"}}' @controllers.HomeController.config("host")</code></p>
 
@@ -79,8 +80,7 @@
   <h3>Data-extension-API</h3>
 
   @desc("Property-proposals (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-property-proposals\">spec</a>)", routes.Reconcile.properties("","Work",""))
-  <p><b>Query: GET (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-service\">spec</a>)</b><br/>
-  <a href='@controllers.HomeController.config("host")/?extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}'>/?extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}</a>
+  @desc("Extend: GET (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-service\">spec</a>)", routes.Reconcile.main(extend="{\"ids\":[\"1081942517\",\"4791358-7\"],\"properties\":[{\"id\":\"preferredName\"},{\"id\":\"firstAuthor\"}]}"))
   <p><b>Extend: POST</b><br/>
   <code>curl --data 'extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}' @controllers.HomeController.config("host")</code></p>
 

--- a/app/views/reconcile.scala.html
+++ b/app/views/reconcile.scala.html
@@ -18,7 +18,7 @@
 
   <p>Dieser Dienst ermöglicht den Abgleich eigener Daten mit der Gemeinsamen Normdatei, insbesondere mit OpenRefine, einem nicht nur im Bibliotheksbereich weitverbreiteten Werkzeug. OpenRefine bietet zahlreiche Funktionalitäten zur Bereinigung und Transformation von Daten, sowie zum Abgleich (Reconciliation) mit externen Datenquellen und zur Anreicherung auf Basis der abgeglichenen Daten. Dieser Dienst stellt die GND als eine solche Datenquelle in OpenRefine bereit. Der Dienst kann zugleich auch in anderen Anwendungen verwendet werden, z. B. im Bibliotheksmanagementsystem Alma über Alma Refine (s. <a href="https://reconciliation-api.github.io/census/clients/">weitere Clients</a>).</p>
 
-  <p>Service-URL: <code>@controllers.HomeController.config("host")@routes.Reconcile.reconcile()</code></p>
+  <p>Service-URL: <code>@controllers.HomeController.config("host")</code></p>
 
   <h2>Daten und Werkzeuge</h2>
 
@@ -48,11 +48,11 @@
   <h3>Allgemeine API <small>(<a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410">spec</a>)</small></h3>
 
   <p><b>Service</b><br/>
-  <code>curl @controllers.HomeController.config("host")@routes.Reconcile.reconcile()</code>
+  <code>curl @controllers.HomeController.config("host")</code>
   <p><b>JSONP-callback</b><br/>
-  <code>curl @controllers.HomeController.config("host")@routes.Reconcile.main("jsonp")</code>
+  <code>curl @controllers.HomeController.config("host")?callback=jsonp</code>
   <p><b>CORS-header</b><br/>
-  <code>curl --head @controllers.HomeController.config("host")@routes.Reconcile.reconcile() | grep Access-Control-Allow-Origin</code>
+  <code>curl --head @controllers.HomeController.config("host") | grep Access-Control-Allow-Origin</code>
   </p>
 
   <h3>View-API</h3>
@@ -62,9 +62,10 @@
 
   <h3>Query-API <small>(<a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#reconciliation-queries">spec</a>)</small></h3>
 
-  @desc("Query: GET", routes.Reconcile.main(queries="{\"q1\":{\"query\":\"Twain, Mark\"}}"))
+  <p><b>Query: GET</b><br/>
+  <a href='@controllers.HomeController.config("host")/?queries={"q1":{"query":"Twain, Mark"}}'>/?queries={"q1":{"query":"Twain, Mark"}}</a>
   <p><b>Query: POST</b><br/>
-  <code>curl --data 'queries={"q1":{"query":"Twain, Mark"}}' @controllers.HomeController.config("host")@routes.Reconcile.reconcile()</code></p>
+  <code>curl --data 'queries={"q1":{"query":"Twain, Mark"}}' @controllers.HomeController.config("host")</code></p>
 
   <h3>Suggest-API <small>(<a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#suggest-services">spec</a>)</small></h3>
 
@@ -78,8 +79,9 @@
   <h3>Data-extension-API</h3>
 
   @desc("Property-proposals (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-property-proposals\">spec</a>)", routes.Reconcile.properties("","Work",""))
-  @desc("Extend: GET (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-service\">spec</a>)", routes.Reconcile.main(extend="{\"ids\":[\"1081942517\",\"4791358-7\"],\"properties\":[{\"id\":\"preferredName\"},{\"id\":\"firstAuthor\"}]}"))
+  <p><b>Query: GET (<a href=\"https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/#data-extension-service\">spec</a>)</b><br/>
+  <a href='@controllers.HomeController.config("host")/?extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}'>/?extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}</a>
   <p><b>Extend: POST</b><br/>
-  <code>curl --data 'extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}' @controllers.HomeController.config("host")@routes.Reconcile.reconcile()</code></p>
+  <code>curl --data 'extend={"ids":["1081942517","4791358-7"],"properties":[{"id":"preferredName"},{"id":"firstAuthor"}]}' @controllers.HomeController.config("host")</code></p>
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,7 +1,7 @@
 # This is the main configuration file for the application.
 # https://www.playframework.com/documentation/latest/ConfigFile
 
-host : "https://lobid.org"
+host : "https://reconcile.lobid.org"
 
 dontShowOnMainPage: ["1012979-0"]
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,7 +1,10 @@
 # This is the main configuration file for the application.
 # https://www.playframework.com/documentation/latest/ConfigFile
 
-host : "https://reconcile.lobid.org"
+host {
+	main: "https://lobid.org"
+	reconcile: "https://reconcile.gnd.network"
+}
 
 dontShowOnMainPage: ["1012979-0"]
 

--- a/conf/routes
+++ b/conf/routes
@@ -2,17 +2,17 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-# Handle trailing slashes
-GET     /gnd/reconcile/     controllers.Reconcile.main(callback ?= "", queries ?= "", extend ?= "")
-POST    /gnd/reconcile/     controllers.Reconcile.reconcile()
-GET     /*path/             controllers.HomeController.redirectSlash(path: String)
-
 #OpenRefine reconciliation endpoint
-GET     /gnd/reconcile            controllers.Reconcile.main(callback ?= "", queries ?= "", extend ?= "")
-POST    /gnd/reconcile            controllers.Reconcile.reconcile()
+GET     /gnd/reconcile             controllers.Default.redirect(to = "/gnd/reconcile/")
+POST    /gnd/reconcile             controllers.Reconcile.reconcile()
+GET     /gnd/reconcile/            controllers.Reconcile.main(callback ?= "", queries ?= "", extend ?= "")
+POST    /gnd/reconcile/            controllers.Reconcile.reconcile()
 GET     /gnd/reconcile/properties controllers.Reconcile.properties(callback ?= "", type ?= "", limit ?= "")
 GET     /gnd/reconcile/suggest/:service   controllers.Reconcile.suggest(callback ?= "", service, prefix, type ?= "", type_strict ?= "", limit: Int ?= 10, start: Int ?= 0)
 GET     /gnd/reconcile/flyout/:service    controllers.Reconcile.flyout(callback ?= "", service, id)
+
+# Handle trailing slashes
+GET     /*path/             controllers.HomeController.redirectSlash(path: String)
 
 GET     /gnd                controllers.HomeController.index
 

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 #OpenRefine reconciliation endpoint
-GET     /gnd/reconcile             controllers.Default.redirect(to = "/gnd/reconcile/")
+GET     /gnd/reconcile             controllers.HomeController.redirectSlash(path = "gnd/reconcile/")
 POST    /gnd/reconcile             controllers.Reconcile.reconcile()
 GET     /gnd/reconcile/            controllers.Reconcile.main(callback ?= "", queries ?= "", extend ?= "")
 POST    /gnd/reconcile/            controllers.Reconcile.reconcile()

--- a/test/controllers/ReconcileIntegrationTest.java
+++ b/test/controllers/ReconcileIntegrationTest.java
@@ -44,11 +44,6 @@ public class ReconcileIntegrationTest extends IndexTest {
 
 	@Test
 	public void reconcileMetadataRequestNoCallback() {
-		metadataRequest("/gnd/reconcile");
-	}
-
-	@Test
-	public void reconcileMetadataRequestNoCallbackTrailingSlash() {
 		metadataRequest("/gnd/reconcile/");
 	}
 
@@ -93,7 +88,7 @@ public class ReconcileIntegrationTest extends IndexTest {
 
 	@Test
 	public void reconcileMetadataRequestWithCallback() {
-		metadataRequestWithCallback("/gnd/reconcile?callback=jsonp");
+		metadataRequestWithCallback("/gnd/reconcile/?callback=jsonp");
 	}
 
 	@Test
@@ -166,7 +161,7 @@ public class ReconcileIntegrationTest extends IndexTest {
 	}
 
 	@Test
-	// curl -g 'localhost:9000/gnd/reconcile?queries={"q99":{"query":"*"}}'
+	// curl -g 'localhost:9000/gnd/reconcile/?queries={"q99":{"query":"*"}}'
 	public void reconcileRequestGetWithReservedChars() {
 		Application application = fakeApplication();
 		running(application, () -> {
@@ -174,7 +169,7 @@ public class ReconcileIntegrationTest extends IndexTest {
 			try {
 				result = route(application,
 						fakeRequest(GET,
-								"/gnd/reconcile?queries=" + URLEncoder.encode(
+								"/gnd/reconcile/?queries=" + URLEncoder.encode(
 										"{\"q99\":{\"query\":\"Conference +=<>(){}[]^ (1997 : Kyoto / Japan)\"}}",
 										StandardCharsets.UTF_8.name())));
 			} catch (UnsupportedEncodingException e) {
@@ -234,7 +229,7 @@ public class ReconcileIntegrationTest extends IndexTest {
 
 	@Test
 	// curl -g
-	// 'localhost:9000/gnd/reconcile?extend=
+	// 'localhost:9000/gnd/reconcile/?extend=
 	// {"ids":[],"properties":[{"id":"geographicAreaCode"},{"id":"professionOrOccupation"}]}'
 	// See https://github.com/hbz/lobid-gnd/issues/241
 	public void extendRequestMeta() {
@@ -246,7 +241,7 @@ public class ReconcileIntegrationTest extends IndexTest {
 				"{\"id\":\"geographicAreaCode\"}," + //
 				"{\"id\":\"professionOrOccupation\"}]}";
 				result = route(application, fakeRequest(GET,
-						"/gnd/reconcile?extend=" + URLEncoder.encode(extensionQuery, StandardCharsets.UTF_8.name())));
+						"/gnd/reconcile/?extend=" + URLEncoder.encode(extensionQuery, StandardCharsets.UTF_8.name())));
 			} catch (UnsupportedEncodingException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
Basic idea: we replace the internal `@routes.Reconcile.reconcile()` route (`/gnd/reconcile/`) with the host name from `conf/application.conf` (set to `https://reconcile.lobid.org` for testing). The web server proxies `/` to `/gnd/reconcile/` (as well as `/gnd/` -> `/gnd/` for assets and view / preview links).