### PR TITLE
434 fix query cleaning

### DIFF
--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -541,7 +541,7 @@ public class Reconcile extends Controller {
 	}
 
 	private static String clean(String in) {
-		String out = in.replaceAll("[-:+=&|><!(){}\\[\\]\"~*?\\\\/\\^]", " ");
+		String out = in.replaceAll("[-:+=&|><!(){}\\[\\]\"~*?\\/\\^]", " ");
 		Logger.info("Cleaned invalid query string '{}' to: '{}'", in, out);
 		return out;
 	}

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -541,7 +541,7 @@ public class Reconcile extends Controller {
 	}
 
 	private static String clean(String in) {
-		String out = in.replaceAll("[-:+=&|><!(){}\\[\\]\"~*?\\/\\^]", " ");
+		String out = in.replaceAll("[-:+=&|><!(){}\\[\\]\"~*?\\\\/\\^]", " ");
 		Logger.info("Cleaned invalid query string '{}' to: '{}'", in, out);
 		return out;
 	}

--- a/app/controllers/Reconcile.java
+++ b/app/controllers/Reconcile.java
@@ -541,7 +541,7 @@ public class Reconcile extends Controller {
 	}
 
 	private static String clean(String in) {
-		String out = in.replaceAll("[:+\\-=<>(){}\\[\\]^]", " ");
+		String out = in.replaceAll("[-:+=&|><!(){}\\[\\]\"~*?\\\\/\\^]", " ");
 		Logger.info("Cleaned invalid query string '{}' to: '{}'", in, out);
 		return out;
 	}

--- a/test/controllers/ReconcileUnitTest.java
+++ b/test/controllers/ReconcileUnitTest.java
@@ -23,8 +23,10 @@ public class ReconcileUnitTest extends IndexTest {
 
 	@Test
 	public void preprocessReconciliationQuery_removeSpecialCharacters() {
-		assertThat(reconcile.preprocess("Conference +=<>(){}[]^ (1997 : Kyoto : Japan)"),
-				equalToIgnoringWhiteSpace("Conference 1997 Kyoto Japan"));
+		String reserved = "+ - = && || > < ! ( ) { } [ ] ^ \" ~ * ? : \\ /";
+		String input = "Test " + reserved + " String";
+		String expected = "Test String";
+		assertThat(reconcile.preprocess(input), equalToIgnoringWhiteSpace(expected));
 	}
 
 	@Test


### PR DESCRIPTION
These are the reserved characters: 
`+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /` 
according to https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-query-string-query.html#_reserved_characters

We need to remove all of them from the query string.

Resolves #434 